### PR TITLE
refactor(midi): make entry a val in driver selection

### DIFF
--- a/app/src/main/java/com/kimjisub/launchpad/midi/MidiConnection.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/MidiConnection.kt
@@ -281,7 +281,7 @@ object MidiConnection {
 			val exactEntry = driverRegistryExact[pid]
 			val rangeEntry = driverRegistryRanges.firstOrNull { pid in it.pidStart..it.pidEnd }?.entry
 
-			var entry = nameEntry ?: exactEntry ?: rangeEntry
+			val entry = nameEntry ?: exactEntry ?: rangeEntry
 
 			if (entry != null) {
 				val deviceId = if (rangeEntry != null) {


### PR DESCRIPTION
## Summary
Follow-up cleanup to #25. The `entry` local in `MidiConnection.initDevice()` is assigned once from the `nameEntry ?: exactEntry ?: rangeEntry` fallback chain and never reassigned, so `val` is correct. This clears the Kotlin "variable is never modified" warning that the CFW driver registry introduced.

## Change
- `MidiConnection.kt`: `var entry` → `val entry` (1 line)

## Verification
- `:app:compileDebugKotlin` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)