### PR TITLE
chore(github): add issue forms and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug report
 description: A crash, wrong behavior, or a Launchpad that does not work
 title: "[Bug] "
+labels: ["bug", "platform:android", "waiting:agent"]
 body:
   - type: markdown
     attributes:
@@ -44,7 +45,19 @@ body:
         - Launchpad Pro MK2 with custom firmware (CFW)
         - Matrix
         - Midi Fighter
+        - Master keyboard / other MIDI keyboard
         - Other (name it in the steps)
+    validations:
+      required: true
+  - type: dropdown
+    id: without-hardware
+    attributes:
+      label: Does it also happen with no Launchpad connected?
+      description: This tells us whether we can reproduce it on an emulator or need the hardware.
+      options:
+        - "Yes, it also happens with no Launchpad connected"
+        - "No, only when the Launchpad is connected"
+        - "Not applicable (I do not use a Launchpad)"
     validations:
       required: true
   - type: textarea
@@ -73,3 +86,5 @@ body:
     id: unipack
     attributes:
       label: UniPack (if it only happens with one)
+      description: Its name and where you got it (store link or download URL). To share the file itself, zip it and drag it into the steps box above.
+      placeholder: "Faded (store), or https://..."

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: A crash, wrong behavior, or a Launchpad that does not work
+title: "[Bug] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. English or Korean is fine (한국어로 써도 됩니다).
+        The version and device fields are what we need most; a report without them usually stalls on a follow-up question.
+  - type: input
+    id: app-version
+    attributes:
+      label: UniPad version
+      description: Settings > Info in the app, or the Play Store listing
+      placeholder: "4.1.3 (109)"
+    validations:
+      required: true
+  - type: input
+    id: device
+    attributes:
+      label: Phone or tablet model
+      placeholder: "Samsung Galaxy S23, Infinix X6731, ..."
+    validations:
+      required: true
+  - type: input
+    id: android-version
+    attributes:
+      label: Android version
+      placeholder: "14"
+    validations:
+      required: true
+  - type: dropdown
+    id: launchpad
+    attributes:
+      label: Launchpad or MIDI device
+      options:
+        - None (touch screen only)
+        - Launchpad S / Mini (original)
+        - Launchpad MK2
+        - Launchpad Pro
+        - Launchpad X
+        - Launchpad Mini MK3
+        - Launchpad Pro MK3
+        - Launchpad Pro MK2 with custom firmware (CFW)
+        - Matrix
+        - Midi Fighter
+        - Other (name it in the steps)
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open UniPad
+        2. Plug in the Launchpad
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-actual
+    attributes:
+      label: What you expected, and what happened instead
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Crash log (if it crashed)
+      description: With the phone connected to a computer, run `adb logcat -d -b crash > crash.txt` and paste the FATAL EXCEPTION block. If you cannot, say so; we will look on our side.
+      render: text
+  - type: input
+    id: unipack
+    attributes:
+      label: UniPack (if it only happens with one)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: UniPad Discord
+    url: https://discord.gg/ESDgyNs
+    about: Quick questions, sharing UniPacks, community help
+  - name: Docs (UniPack and theme formats)
+    url: https://unipad.io/docs
+    about: How UniPacks and themes are structured, and how to make one

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature request
 description: Propose something new, or a change to how UniPad behaves
 title: "[Feature] "
+labels: ["enhancement", "platform:android", "waiting:agent"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Propose something new, or a change to how UniPad behaves
+title: "[Feature] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        English or Korean is fine (한국어로 써도 됩니다). The first question matters most: what are you trying to do?
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do that you cannot today?
+      placeholder: "When I ... I want ... but UniPad ..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What should UniPad do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Workarounds or other apps you have tried
+  - type: checkboxes
+    id: platforms
+    attributes:
+      label: Where should this exist?
+      options:
+        - label: Android
+        - label: iOS
+        - label: Web (unipad.io)
+  - type: dropdown
+    id: unipack-compat
+    attributes:
+      label: Does this change how existing UniPacks load or play?
+      description: UniPack compatibility is the one thing UniPad never breaks. If yes, explain above.
+      options:
+        - "No"
+        - "Not sure"
+        - "Yes (explained above)"
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## What and why
+
+## How you tested it
+Device, emulator, or simulator, and what you did. Paste the command if there is one.
+
+## UniPack compatibility
+- [ ] Existing UniPacks load and play exactly as before
+- [ ] This changes UniPack behavior, explained above
+
+## Related issues
+Fixes #
+
+## Screenshots or video (for UI changes)


### PR DESCRIPTION
## Summary
Structured issue forms and a PR template so reports arrive with what triage needs.

- **Bug report form**: requires UniPad version, device model, Android version, Launchpad model (dropdown covering every user-selectable driver we ship, including Pro MK2 CFW and the generic Master Keyboard), and whether the bug also happens with no Launchpad connected — the answer that decides emulator-reproducible vs hardware-only. Asks for `adb logcat -d -b crash` output and the UniPack if relevant. Applies `bug`, `platform:android`, `waiting:agent`.
- **Feature request form**: problem first, then proposal, platforms, and an explicit "does this change how existing UniPacks load or play?" question. Applies `enhancement`, `platform:android`, `waiting:agent`.
- **Blank issues disabled**; contact links point to the UniPad Discord (`discord.gg/ESDgyNs`, verified valid) and unipad.io/docs.
- **PR template**: what/why, how tested, UniPack compatibility checkbox, related issues.

## Why now
#26 arrived with an empty body and #22 without device or log, and both waited months partly because there was nothing to act on. These forms make the first message actionable.

## Review
Reviewed by five independent read-only reviewers with adversarial verification; four confirmed findings applied in the second commit (labels, Master Keyboard option, no-hardware question, UniPack hint). YAML validated against GitHub's issue-form schema locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)