### PR TITLE
fix(main): Run UniPack delete off the main thread

### DIFF
--- a/app/src/main/java/com/kimjisub/launchpad/activity/MainActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/MainActivity.kt
@@ -244,9 +244,15 @@ class MainActivity : BaseActivity() {
 						confirmButton = {
 							TextButton(onClick = {
 								deleteTargetItem = null
-								item.unipack.delete()
 								selectedItem = null
-								update()
+								listRefreshing = true
+								lifecycleScope.launch(Dispatchers.IO) {
+									item.unipack.delete()
+									withContext(Dispatchers.Main) {
+										listRefreshing = false
+										update()
+									}
+								}
 							}) {
 								Text(stringResource(string.accept))
 							}


### PR DESCRIPTION
## What and why

Play vitals (28 days to 2026-09-02, versionCode 109) shows 8 ANRs with the main thread blocked in `FileManager.deleteDirectory` (`FileManager.kt:109`) via `UniPackFolder.delete` (`UniPackFolder.kt:86`), called from the delete confirmation dialog in `MainActivity` (`MainActivity.kt:247` on main at the time of the trace).

Cause: the confirm button's `onClick` called `item.unipack.delete()` synchronously, so the recursive file-by-file delete ran on the main thread and froze the UI for seconds on large packs.

Fix (`app/src/main/java/com/kimjisub/launchpad/activity/MainActivity.kt:245-255`): the confirm handler now clears the selection, sets `listRefreshing = true` so the existing pull-to-refresh indicator shows while the delete runs, launches `item.unipack.delete()` on `lifecycleScope.launch(Dispatchers.IO)`, then switches back to `Dispatchers.Main`, clears the indicator, and calls `update()` to refresh the list. This is the same dispatch pattern `update()` and `UniPackImporter` already use. The confirmation dialog is unchanged.

## How you tested it

- `./gradlew :app:compileDebugKotlin -q` -> no output, exit 0
- `./gradlew :app:testDebugUnitTest --tests 'com.kimjisub.launchpad.manager.FileManagerTest' -q` -> exit 0; JUnit report: `tests="26" skipped="0" failures="0" errors="0"` (covers `deleteDirectory`, the code that now runs on IO)

No new unit test: the changed code is a Compose click handler inside an Activity that needs `lifecycleScope` and the Android main looper, so it is not testable as pure Kotlin under `app/src/test`. The delete logic itself is already covered by `FileManagerTest.deleteDirectory_*`.

## UniPack compatibility
- [x] Existing UniPacks load and play exactly as before

## Related issues
Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
