### PR TITLE
fix(unipack): Record missing pack files as errors instead of crashing

### DIFF
--- a/app/src/main/java/com/kimjisub/launchpad/unipack/UniPackFolder.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/unipack/UniPackFolder.kt
@@ -9,6 +9,7 @@ import com.kimjisub.launchpad.unipack.struct.Sound
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileInputStream
+import java.io.FileNotFoundException
 import java.io.InputStreamReader
 
 class UniPackFolder(val rootFolder: File) : UniPack() {
@@ -93,7 +94,14 @@ class UniPackFolder(val rootFolder: File) : UniPack() {
 
 	private fun info() {
 		val file = infoFile ?: return
-		BufferedReader(InputStreamReader(FileInputStream(file))).use { reader ->
+		val inputStream = try {
+			FileInputStream(file)
+		} catch (e: FileNotFoundException) {
+			addErr("info : file was not found")
+			criticalError = true
+			return
+		}
+		BufferedReader(InputStreamReader(inputStream)).use { reader ->
 			while (true) {
 				val s = reader.readLine()?.trim() ?: break
 				if (s.isEmpty()) continue
@@ -136,7 +144,14 @@ class UniPackFolder(val rootFolder: File) : UniPack() {
 		}
 		soundTable = table
 		soundCount = 0
-		BufferedReader(InputStreamReader(FileInputStream(keySoundFile))).use { reader ->
+		val inputStream = try {
+			FileInputStream(keySoundFile)
+		} catch (e: FileNotFoundException) {
+			addErr("keySound : file was not found")
+			criticalError = true
+			return
+		}
+		BufferedReader(InputStreamReader(inputStream)).use { reader ->
 			while (true) {
 				val s = reader.readLine()?.trim() ?: break
 				if (s.isEmpty()) continue
@@ -244,7 +259,13 @@ class UniPackFolder(val rootFolder: File) : UniPack() {
 						continue
 					}
 					val ledList = ArrayList<LedAnimation.LedEvent>()
-					BufferedReader(InputStreamReader(FileInputStream(file))).use { reader ->
+					val inputStream = try {
+						FileInputStream(file)
+					} catch (e: FileNotFoundException) {
+						addErr("keyLed : [$fileName] file was not found")
+						continue
+					}
+					BufferedReader(InputStreamReader(inputStream)).use { reader ->
 						loop@ while (true) {
 							val s = reader.readLine()?.trim() ?: break
 							if (s.isEmpty()) continue@loop
@@ -357,7 +378,13 @@ class UniPackFolder(val rootFolder: File) : UniPack() {
 		autoPlayTable = autoPlay
 		val map = Array(buttonX) { IntArray(buttonY) }
 		var currChain = 0
-		BufferedReader(InputStreamReader(FileInputStream(autoPlayFile))).use { reader ->
+		val inputStream = try {
+			FileInputStream(autoPlayFile)
+		} catch (e: FileNotFoundException) {
+			addErr("autoPlay : file was not found")
+			return
+		}
+		BufferedReader(InputStreamReader(inputStream)).use { reader ->
 			loop@ while (true) {
 				val s = reader.readLine()?.trim() ?: break
 				if (s.isEmpty()) continue@loop

--- a/app/src/test/java/com/kimjisub/launchpad/unipack/UniPackFolderMissingFileTest.kt
+++ b/app/src/test/java/com/kimjisub/launchpad/unipack/UniPackFolderMissingFileTest.kt
@@ -1,0 +1,108 @@
+package com.kimjisub.launchpad.unipack
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class UniPackFolderMissingFileTest {
+
+	@get:Rule
+	val tmp = TemporaryFolder()
+
+	private fun createPack(): File {
+		val root = tmp.newFolder("pack")
+		File(root, "info").writeText("title=Test\nproducerName=Tester\nbuttonX=8\nbuttonY=8\nchain=1\n")
+		File(root, "keySound").writeText("1 1 1 a.wav\n")
+		File(root, "sounds").mkdir()
+		File(root, "sounds/a.wav").writeText("")
+		File(root, "keyLed").mkdir()
+		File(root, "keyLed/1 1 1 1").writeText("o 1 1 3\nd 100\n")
+		File(root, "autoPlay").writeText("o 1 1\nd 100\n")
+		return root
+	}
+
+	private fun errors(pack: UniPack): String = pack.errorDetail.orEmpty()
+
+	@Test
+	fun intactPack_loadsWithoutErrors() {
+		val pack = UniPackFolder(createPack()).load().loadDetail()
+
+		assertNull(pack.errorDetail)
+		assertFalse(pack.criticalError)
+		assertEquals(1, pack.soundCount)
+		assertEquals(1, pack.ledTableCount)
+		assertEquals(2, pack.autoPlayTable?.elements?.size)
+	}
+
+	@Test
+	fun autoPlayFileDeletedAfterCheckFile_isRecordedAsError() {
+		val root = createPack()
+		val pack = UniPackFolder(root).load()
+		assertTrue(File(root, "autoPlay").delete())
+
+		pack.loadDetail()
+
+		assertTrue(errors(pack), errors(pack).contains("autoPlay : file was not found"))
+		assertFalse(pack.criticalError)
+		assertTrue(pack.detailLoaded)
+		assertEquals(1, pack.soundCount)
+		assertEquals(1, pack.ledTableCount)
+		assertNotNull(pack.autoPlayTable)
+		assertEquals(0, pack.autoPlayTable?.elements?.size)
+	}
+
+	@Test
+	fun keyLedFileUnreadable_isRecordedAsError() {
+		val root = createPack()
+		val pack = UniPackFolder(root).load()
+		val ledFile = File(root, "keyLed/1 1 1 1")
+		ledFile.setReadable(false, false)
+		assumeFalse("cannot make file unreadable (running as root?)", ledFile.canRead())
+
+		try {
+			pack.loadDetail()
+		} finally {
+			ledFile.setReadable(true, false)
+		}
+
+		assertTrue(errors(pack), errors(pack).contains("keyLed : [1 1 1 1] file was not found"))
+		assertFalse(pack.criticalError)
+		assertTrue(pack.detailLoaded)
+		assertEquals(1, pack.soundCount)
+		assertEquals(0, pack.ledTableCount)
+		assertEquals(2, pack.autoPlayTable?.elements?.size)
+	}
+
+	@Test
+	fun keySoundFileDeletedAfterCheckFile_isCriticalError() {
+		val root = createPack()
+		val pack = UniPackFolder(root).load()
+		assertTrue(File(root, "keySound").delete())
+
+		pack.loadDetail()
+
+		assertTrue(errors(pack), errors(pack).contains("keySound : file was not found"))
+		assertTrue(pack.criticalError)
+		assertEquals(0, pack.soundCount)
+	}
+
+	@Test
+	fun infoFileDeletedAfterCheckFile_isCriticalError() {
+		val root = createPack()
+		val pack = UniPackFolder(root)
+		pack.checkFile()
+		assertTrue(File(root, "info").delete())
+
+		pack.loadInfo()
+
+		assertTrue(errors(pack), errors(pack).contains("info : file was not found"))
+		assertTrue(pack.criticalError)
+	}
+}


### PR DESCRIPTION
## What and why

Play vitals (versionCode 109, three clusters, ~13 users/28d) show `java.io.FileNotFoundException` thrown from `UniPackFolder.keyLed` and `UniPackFolder.autoPlay` during `loadDetailWithProgress`. `MainPackPanelViewModel.kt:61` runs `unipack.loadDetail()` inside `viewModelScope.launch(Dispatchers.IO)` with no catch, so the exception takes the process down.

**Cause.** `UniPackFolder` opens pack files with `FileInputStream(...)` after they were seen by `checkFile()` / `listFiles()`. If a file is gone or unreadable by the time it is opened (partially deleted pack, interrupted import, SAF migration leftovers), the constructor throws. The surrounding `try` blocks only catch `NumberFormatException` / `IndexOutOfBoundsException`:

- `app/src/main/java/com/kimjisub/launchpad/unipack/UniPackFolder.kt:247` (`keyLed`, trace line 246 on 109)
- `app/src/main/java/com/kimjisub/launchpad/unipack/UniPackFolder.kt:360` (`autoPlay`, trace line 355 on 109)
- the same unguarded open in `info()` (`:96`) and `keySound()` (`:139`)

**Fix.** Each `FileInputStream` open is wrapped in `try { ... } catch (e: FileNotFoundException)` and the problem is recorded with the existing `addErr(...)`:

- `keyLed`: `addErr("keyLed : [<name>] file was not found")` and `continue` to the next LED file.
- `autoPlay`: `addErr("autoPlay : file was not found")` and return, leaving an empty `autoPlayTable`.
- `info` / `keySound`: `addErr(...)`, set `criticalError = true` (same treatment `checkFile()` already gives a missing info/keySound) and return.

The pack therefore loads as broken (warning or error in `PlayActivity` / the main list) instead of crashing. Packs whose files exist go through exactly the same code as before; only the exception branch is new.

## How you tested it

```
./gradlew :app:compileDebugKotlin -q
# exit 0, no output

./gradlew :app:testDebugUnitTest --tests 'com.kimjisub.launchpad.unipack.UniPackFolderMissingFileTest' -q
# exit 0; JUnit XML: tests="5" skipped="0" failures="0" errors="0"
```

New JVM test `app/src/test/java/com/kimjisub/launchpad/unipack/UniPackFolderMissingFileTest.kt` builds a minimal pack in a `TemporaryFolder`, runs `load()`, then deletes `autoPlay` / `keySound` / `info` (or makes the keyLed file unreadable, skipped via `Assume` when running as root) before `loadDetail()` / `loadInfo()`, and asserts the error string, `criticalError`, and that the other phases still load. An intact-pack test asserts `errorDetail == null` with the expected sound/LED/autoPlay counts.

## UniPack compatibility

- [x] Existing UniPacks load and play exactly as before

## Related issues

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)
