### PR TITLE
fix(workspace): skip null entries from getExternalFilesDirs

### DIFF
--- a/app/src/main/java/com/kimjisub/launchpad/manager/WorkspaceManager.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/manager/WorkspaceManager.kt
@@ -50,7 +50,7 @@ class WorkspaceManager(val context: Context) : KoinComponent {
 			val dirs = context.getExternalFilesDirs("UniPack")
 			var externalIndex = 1
 
-			dirs.forEach { file ->
+			dirs.filterNotNull().forEach { file ->
 				if (file.absolutePath.contains("/storage/emulated/0")) return@forEach
 
 				val name = context.getString(R.string.workspace_external_sd_card_format, externalIndex)
@@ -194,7 +194,7 @@ class WorkspaceManager(val context: Context) : KoinComponent {
 	/** Legacy UniPack directory: getExternalFilesDirs("UniPack") on internal storage */
 	fun getLegacyUniPackDir(): File? {
 		val dirs = context.getExternalFilesDirs("UniPack")
-		val internal = dirs.firstOrNull { it.absolutePath.contains("/storage/emulated/0") }
+		val internal = dirs.filterNotNull().firstOrNull { it.absolutePath.contains("/storage/emulated/0") }
 		return if (internal != null && internal.exists() && internal.canRead()) internal else null
 	}
 

--- a/app/src/test/java/com/kimjisub/launchpad/manager/WorkspaceManagerTest.kt
+++ b/app/src/test/java/com/kimjisub/launchpad/manager/WorkspaceManagerTest.kt
@@ -163,6 +163,37 @@ class WorkspaceManagerTest {
 	}
 
 	@Test
+	fun availableWorkspaces_skipsUnmountedExternalDirs() {
+		val sdCardDir = File(tempDir, "sdcard")
+		sdCardDir.mkdirs()
+
+		every { mockContext.getExternalFilesDir(null) } returns null
+		every { mockContext.filesDir } returns File(tempDir, "internal")
+		every { mockContext.getExternalFilesDirs("UniPack") } returns arrayOf(sdCardDir, null)
+
+		val manager = WorkspaceManager(mockContext)
+		val workspaces = manager.availableWorkspaces
+
+		assertEquals(
+			"Unmounted volume should be treated as absent",
+			listOf("External SD Card 1"),
+			workspaces.filter { it.name.contains("SD Card") }.map { it.name }
+		)
+	}
+
+	@Test
+	fun getLegacyUniPackDir_skipsUnmountedExternalDirs() {
+		val internalDir = File(tempDir, "storage/emulated/0/UniPack")
+		internalDir.mkdirs()
+
+		every { mockContext.getExternalFilesDirs("UniPack") } returns arrayOf(null, internalDir)
+
+		val manager = WorkspaceManager(mockContext)
+
+		assertEquals(internalDir, manager.getLegacyUniPackDir())
+	}
+
+	@Test
 	fun availableWorkspaces_appStoragePathEndsWithUnipad() {
 		val appDir = File(tempDir, "app_external")
 		appDir.mkdirs()


### PR DESCRIPTION
## What and why

Play vitals on versionCode 109 (4.1.3) show `NullPointerException: Attempt to invoke virtual method 'java.lang.String java.io.File.getAbsolutePath()' on a null object reference` at `WorkspaceManager.getAvailableWorkspaces (WorkspaceManager.kt:54)`, reached from `MainTotalPanelViewModel.update` on the main screen (38 users / 92 reports in 28 days).

**Cause.** `Context.getExternalFilesDirs()` returns an array whose entries are `null` for storage volumes that are not currently mounted (a removed or not-yet-ready SD card). Two call sites dereferenced every entry unguarded:

- `app/src/main/java/com/kimjisub/launchpad/manager/WorkspaceManager.kt:53-54` (`dirs.forEach { file -> if (file.absolutePath...` ) -- the crashing line from the trace.
- `app/src/main/java/com/kimjisub/launchpad/manager/WorkspaceManager.kt:197` (`dirs.firstOrNull { it.absolutePath...` in `getLegacyUniPackDir`) -- same array, same latent NPE.

**Fix.** Call `filterNotNull()` on the array at both call sites so an unavailable volume is treated as absent rather than fatal. Nothing else changes: mounted volumes are still enumerated in the same order, `/storage/emulated/0` is still skipped for the SD-card list, and the external SD card numbering is unchanged.

## How you tested it

```
./gradlew :app:compileDebugKotlin -q          # exit 0, no output
./gradlew :app:testDebugUnitTest --tests 'com.kimjisub.launchpad.manager.WorkspaceManagerTest' -q
```

Two new tests in `WorkspaceManagerTest` stub `getExternalFilesDirs("UniPack")` with a `null` entry:

- `availableWorkspaces_skipsUnmountedExternalDirs` (`arrayOf(sdCardDir, null)`): no crash, exactly one `External SD Card 1` workspace -- pass
- `getLegacyUniPackDir_skipsUnmountedExternalDirs` (`arrayOf(null, internalDir)`): no crash, returns the internal dir -- pass

Result: 10 tests, 9 pass, 1 fails. The failure is `availableWorkspaces_includesInternalStorage`, which is pre-existing on `main`: it expects an "Internal Storage" workspace, but no code on `main` produces one (`git grep workspace_internal_storage origin/main -- app/src/main` matches only the string resource). It stubs `getExternalFilesDirs` with an empty array, so this change cannot affect it. Left untouched to keep this PR to the crash fix.

## UniPack compatibility

- [x] Existing UniPacks load and play exactly as before

## Related issues

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)
