### PR TITLE
fix(midi): guard MidiManager.openDevice against platform RuntimeException

### DIFF
--- a/app/src/main/java/com/kimjisub/launchpad/midi/MidiConnection.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/MidiConnection.kt
@@ -412,42 +412,47 @@ object MidiConnection {
 			Log.midiDetail("  MIDI API Port[${port.portNumber}]: $dir name=${port.name}")
 		}
 
-		manager.openDevice(targetInfo, { device ->
-			if (device != null) {
-				midiDevice = device
-				Log.midiDetail("MIDI API: Device opened successfully")
+		try {
+			manager.openDevice(targetInfo, { device ->
+				if (device != null) {
+					midiDevice = device
+					Log.midiDetail("MIDI API: Device opened successfully")
 
-				// Open all input ports and send SysEx
-				for (portInfo in targetInfo.ports) {
-					if (portInfo.type == MidiDeviceInfo.PortInfo.TYPE_INPUT) {
-						val port = device.openInputPort(portInfo.portNumber)
-						if (port != null) {
-							midiInputPorts[portInfo.portNumber] = port
-							Log.midiDetail("MIDI API: Opened input port ${portInfo.portNumber} (${portInfo.name})")
+					// Open all input ports and send SysEx
+					for (portInfo in targetInfo.ports) {
+						if (portInfo.type == MidiDeviceInfo.PortInfo.TYPE_INPUT) {
+							val port = device.openInputPort(portInfo.portNumber)
+							if (port != null) {
+								midiInputPorts[portInfo.portNumber] = port
+								Log.midiDetail("MIDI API: Opened input port ${portInfo.portNumber} (${portInfo.name})")
+							}
 						}
 					}
-				}
 
-				// Send SysEx to ALL input ports (port names are empty, we don't know which is DAW)
-				val initData = driver.getInitSysEx()
-				if (initData != null && midiInputPorts.isNotEmpty()) {
-					val (messages, _) = initData
-					for ((portNum, _) in midiInputPorts) {
-						Log.midiDetail("MIDI API: Sending init SysEx (${messages.size} messages) to port $portNum")
-						sendViaMidiApi(messages, portNum)
+					// Send SysEx to ALL input ports (port names are empty, we don't know which is DAW)
+					val initData = driver.getInitSysEx()
+					if (initData != null && midiInputPorts.isNotEmpty()) {
+						val (messages, _) = initData
+						for ((portNum, _) in midiInputPorts) {
+							Log.midiDetail("MIDI API: Sending init SysEx (${messages.size} messages) to port $portNum")
+							sendViaMidiApi(messages, portNum)
+						}
 					}
-				}
 
-				// Delay to ensure SysEx is flushed before closing ports
-				Handler(Looper.getMainLooper()).postDelayed({
-					closeMidiApi()
+					// Delay to ensure SysEx is flushed before closing ports
+					Handler(Looper.getMainLooper()).postDelayed({
+						closeMidiApi()
+						claimUsbAndStart()
+					}, 500)
+				} else {
+					Log.midiDetail("MIDI API: Failed to open device, claiming USB interface directly")
 					claimUsbAndStart()
-				}, 500)
-			} else {
-				Log.midiDetail("MIDI API: Failed to open device, claiming USB interface directly")
-				claimUsbAndStart()
-			}
-		}, Handler(Looper.getMainLooper()))
+				}
+			}, Handler(Looper.getMainLooper()))
+		} catch (e: RuntimeException) {
+			Log.err("MIDI API: openDevice failed, claiming USB interface directly", e)
+			claimUsbAndStart()
+		}
 	}
 
 	private fun closeMidiApi() {


### PR DESCRIPTION
## What and why

Play vitals (28 days to 2026-09-02, versionCode 109): 4 users / 7 reports, all Galaxy S24 FE on Android 16. Plugging in a Launchpad crashed `UsbMidiHandlerActivity.onCreate` and the app would not open until the device was unplugged.

**Cause.** `MidiManager.openDevice` threw a `NullPointerException` from `Parcel.createExceptionOrNull` — the platform MIDI service rejected the call and the framework failed while unmarshalling its own exception (null message). That `RuntimeException` propagated out of `MidiConnection.initMidiApiDevice` (trace line 404 on versionCode 109; the same call is now at `app/src/main/java/com/kimjisub/launchpad/midi/MidiConnection.kt:416` on main) and killed the activity.

**Fix.** Wrap `manager.openDevice(targetInfo, ...)` in `try/catch (RuntimeException)` (`MidiConnection.kt:415-455`). On failure it logs via `Log.err` and falls back to `claimUsbAndStart()`, which is exactly the path the function already takes when the MIDI API is unavailable (`MidiConnection.kt:386`), no matching device is found (`:405`), or the open callback returns a null device (`:449`). The diff is whitespace-heavy because the callback block gained one level of indentation; `git diff -w` shows the 5 added lines.

## How you tested it

- `./gradlew :app:compileDebugKotlin` → `BUILD SUCCESSFUL in 43s`, `27 actionable tasks: 1 executed, 26 up-to-date`.
- No unit test added: `initMidiApiDevice` is private on the `MidiConnection` object and the failure originates inside `android.media.midi.MidiManager` (a final framework class) via Binder. It cannot be constructed or made to throw in a plain JVM test without Robolectric or mocking the framework, so a test would not exercise the real path. The crash cannot be reproduced without the affected device; the guard is safe regardless since it only widens an existing fallback.

## UniPack compatibility

- [x] Existing UniPacks load and play exactly as before

The change only affects the USB-attach path when `openDevice` throws; the success and null-device paths are untouched.

## Related issues

Fixes #35
Related: #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
