### PR TITLE
fix(play): guard refreshWatermark until channelManager exists

### DIFF
--- a/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
@@ -918,7 +918,7 @@ class PlayActivity : BaseActivity() {
 			vm.traceLogInit()
 			vm.proLightMode(vm.scbProLightMode.isChecked())
 			vm.uiLoaded = true
-			vm.chainBtnsRefresh()
+			vm.refreshWatermark()
 			updateVolumeUI()
 			controller = midiController
 		} catch (e: RuntimeException) {

--- a/app/src/main/java/com/kimjisub/launchpad/viewmodel/PlayActivityViewModel.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/viewmodel/PlayActivityViewModel.kt
@@ -437,6 +437,7 @@ class PlayActivityViewModel(
 
 	fun refreshWatermark() {
 		log("refreshWatermark")
+		if (!isChannelManagerInitialized) return
 		val topBar = IntArray(TOP_BAR_COUNT)
 		val showUi: Boolean
 		val showUiUnipad: Boolean

--- a/app/src/test/java/com/kimjisub/launchpad/viewmodel/PlayActivityViewModelTest.kt
+++ b/app/src/test/java/com/kimjisub/launchpad/viewmodel/PlayActivityViewModelTest.kt
@@ -1,0 +1,54 @@
+package com.kimjisub.launchpad.viewmodel
+
+import com.kimjisub.launchpad.db.repository.UnipackRepository
+import com.kimjisub.launchpad.manager.ChannelManager
+import com.kimjisub.launchpad.manager.ChannelManager.Channel
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PlayActivityViewModelTest {
+
+	private lateinit var vm: PlayActivityViewModel
+
+	@Before
+	fun setUp() {
+		vm = PlayActivityViewModel(mockk<UnipackRepository>())
+	}
+
+	@Test
+	fun toggleOptionWindow_doesNotThrow_beforeChannelManagerIsInitialized() {
+		assertFalse(vm.isChannelManagerInitialized)
+
+		vm.toggleOptionWindow(true)
+
+		assertTrue(vm.isOptionWindowVisible)
+		assertFalse(vm.isChannelManagerInitialized)
+	}
+
+	@Test
+	fun refreshWatermark_doesNotThrow_beforeChannelManagerIsInitialized() {
+		assertFalse(vm.isChannelManagerInitialized)
+
+		vm.refreshWatermark()
+
+		assertFalse(vm.isChannelManagerInitialized)
+	}
+
+	@Test
+	fun refreshWatermark_paintsOptionWindowState_onceChannelManagerExists() {
+		vm.toggleOptionWindow(true)
+		vm.channelManager = ChannelManager(8, 8)
+		assertNull(vm.channelManager.get(-1, 7))
+
+		vm.refreshWatermark()
+
+		val item = requireNotNull(vm.channelManager.get(-1, 7)) { "Expected UI top bar LED at function key 7" }
+		assertEquals(Channel.UI, item.channel)
+		assertEquals(PlayActivityViewModel.LED_RED_BRIGHT, item.code)
+	}
+}


### PR DESCRIPTION
## What and why

**Crash (Play vitals, versionCode 109, 15 users / 24 reports):** `kotlin.UninitializedPropertyAccessException` at `PlayActivityViewModel.getChannelManager`, reached via `toggleOptionWindow` -> `refreshWatermark` from the Compose `BackHandler` in `PlayActivity.onCreate`.

**Cause:** `channelManager` is `lateinit` (`PlayActivityViewModel.kt:162`) and is only assigned in `initState()` (`PlayActivityViewModel.kt:199`), which runs after the async UniPack load. The `BackHandler` (`PlayActivity.kt:252-258`) is enabled from the first frame, so a back press during loading calls `toggleOptionWindow` -> `refreshWatermark()`, which touched `channelManager` (`PlayActivityViewModel.kt:465`) without checking the existing `isChannelManagerInitialized` (`PlayActivityViewModel.kt:163`). Line numbers have shifted since the trace (156/533/593 -> 162/465/525) but the path is unchanged.

Other `channelManager` readers (`proLightMode`, `padInit`, `chainBtnsRefresh`, `ledInit`) are only reachable through listeners registered in `initLayout()` or through the option panel / menu button, all of which sit behind `startReady` (set after `initState()`), so `refreshWatermark()` is the single pre-init sink and the only one that needs the guard.

**Fix:**
- `PlayActivityViewModel.refreshWatermark()` (`PlayActivityViewModel.kt:440`): early return while `!isChannelManagerInitialized`. `toggleOptionWindow` still records `isOptionWindowVisible`, so the user's choice survives the load.
- `PlayActivity.initLayout()` (`PlayActivity.kt:921`): call `vm.refreshWatermark()` at the first LED paint after the manager exists, replacing the `vm.chainBtnsRefresh()` call there. `refreshWatermark()` ends with `chainBtnsRefresh()`, so chain LEDs are still refreshed, and the top bar now reflects the option window state chosen during loading. The re-run cannot live in `initState()` itself: `refreshWatermark()` drives `uiCallback.setLedChain`, which indexes the `lateinit` `chainViews` that `start()` allocates only after `initState()` returns.

## How you tested it

Worktree on `origin/main` (`3dbfb57a`), macOS.

```
./gradlew :app:compileDebugKotlin -q
# exit 0, no output

./gradlew :app:testDebugUnitTest --tests 'com.kimjisub.launchpad.viewmodel.PlayActivityViewModelTest' -q
# exit 0; report: tests="3" skipped="0" failures="0" errors="0"
```

New pure-JVM test `app/src/test/java/com/kimjisub/launchpad/viewmodel/PlayActivityViewModelTest.kt` covers: `toggleOptionWindow(true)` and `refreshWatermark()` before `channelManager` exists do not throw (both would throw on `main` today), and once `channelManager` is assigned `refreshWatermark()` paints the option window top bar (`Channel.UI`, `LED_RED_BRIGHT` at function key 7).

Not run on a device or emulator in this change; the trace path is the Compose `BackHandler`, which the unit test exercises through the same `toggleOptionWindow` entry point.

## UniPack compatibility
- [x] Existing UniPacks load and play exactly as before
- [ ] This changes UniPack behavior, explained above

No parsing, sound, LED, or autoPlay data path is touched. For square packs `refreshWatermark()` already ran a few ms later via the `initSetting()` checkbox listeners, so the initial LED state is unchanged; for non-square packs the top bar chain views are invisible, and on a Launchpad `onAttach` already ran `refreshWatermark()`.

## Related issues
Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)
