### PR TITLE
fix(autoplay): Guard activeGuides against cross-thread mutation

### DIFF
--- a/app/src/main/java/com/kimjisub/launchpad/unipack/runner/AutoPlayRunner.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/unipack/runner/AutoPlayRunner.kt
@@ -114,7 +114,7 @@ class AutoPlayRunner(
 					guideTimeline = buildGuideTimeline(autoPlay)
 					guideIndex = 0
 					waitingForChain = -1
-					activeGuides.clear()
+					synchronized(activeGuides) { activeGuides.clear() }
 				}
 
 				try {
@@ -133,13 +133,15 @@ class AutoPlayRunner(
 								guideIndex = guideTimeline.indexOfFirst { it.timeMs > elapsed - GUIDE_LOOKAHEAD_MS }
 									.let { if (it < 0) guideTimeline.size else it }
 								waitingForChain = -1
-								activeGuides.clear()
+								synchronized(activeGuides) { activeGuides.clear() }
 							} else {
 								// Switched FROM practice mode — clean up guides
-								for ((key, _) in activeGuides) {
-									listener.onGuideLedUpdate(key / 256, key % 256, 0)
+								synchronized(activeGuides) {
+									for ((key, _) in activeGuides) {
+										listener.onGuideLedUpdate(key / 256, key % 256, 0)
+									}
+									activeGuides.clear()
 								}
-								activeGuides.clear()
 								guideTimeline = emptyList()
 								waitingForChain = -1
 								listener.onRemoveGuide()
@@ -172,42 +174,46 @@ class AutoPlayRunner(
 												// Chain mismatch — pause and show chain indicator
 												waitingForChain = event.chain
 												waitStartTime = currTime
-												for ((key, _) in activeGuides) {
-													listener.onGuideLedUpdate(key / 256, key % 256, 0)
+												synchronized(activeGuides) {
+													for ((key, _) in activeGuides) {
+														listener.onGuideLedUpdate(key / 256, key % 256, 0)
+													}
+													activeGuides.clear()
 												}
-												activeGuides.clear()
 												listener.onRemoveGuide()
 												listener.onGuideChainOn(event.chain)
 												break
 											}
 											val targetWallTimeMs = startTime + event.timeMs
-											activeGuides[guideKey(event.x, event.y)] = targetWallTimeMs
+											synchronized(activeGuides) { activeGuides[guideKey(event.x, event.y)] = targetWallTimeMs }
 											listener.onGuidePadOn(event.x, event.y, targetWallTimeMs)
 											guideIndex++
 										} else break
 									}
 
 									// Guide expiration + launchpad LED brightness update
-									if (activeGuides.isNotEmpty()) {
-										val throttle = currTime - lastGuideUpdateMs >= GUIDE_LED_UPDATE_INTERVAL_MS
-										val iter = activeGuides.iterator()
-										while (iter.hasNext()) {
-											val (key, targetMs) = iter.next()
-											val gx = key / 256
-											val gy = key % 256
-											if (currTime >= targetMs) {
-												// Guide expired — auto-remove
-												iter.remove()
-												listener.onGuideLedUpdate(gx, gy, 0)
-												listener.onGuidePadOff(gx, gy)
-											} else if (throttle) {
-												val remaining = targetMs - currTime
-												val p = (1f - remaining.toFloat() / GUIDE_LOOKAHEAD_MS).coerceIn(0f, 1f)
-												val idx = (p * GUIDE_VELOCITIES.size).toInt().coerceIn(0, GUIDE_VELOCITIES.lastIndex)
-												listener.onGuideLedUpdate(gx, gy, GUIDE_VELOCITIES[idx])
+									synchronized(activeGuides) {
+										if (activeGuides.isNotEmpty()) {
+											val throttle = currTime - lastGuideUpdateMs >= GUIDE_LED_UPDATE_INTERVAL_MS
+											val iter = activeGuides.iterator()
+											while (iter.hasNext()) {
+												val (key, targetMs) = iter.next()
+												val gx = key / 256
+												val gy = key % 256
+												if (currTime >= targetMs) {
+													// Guide expired — auto-remove
+													iter.remove()
+													listener.onGuideLedUpdate(gx, gy, 0)
+													listener.onGuidePadOff(gx, gy)
+												} else if (throttle) {
+													val remaining = targetMs - currTime
+													val p = (1f - remaining.toFloat() / GUIDE_LOOKAHEAD_MS).coerceIn(0f, 1f)
+													val idx = (p * GUIDE_VELOCITIES.size).toInt().coerceIn(0, GUIDE_VELOCITIES.lastIndex)
+													listener.onGuideLedUpdate(gx, gy, GUIDE_VELOCITIES[idx])
+												}
 											}
+											if (throttle) lastGuideUpdateMs = currTime
 										}
-										if (throttle) lastGuideUpdateMs = currTime
 									}
 								}
 
@@ -304,7 +310,7 @@ class AutoPlayRunner(
 		Log.thread("[AutoPlay] 3. Request Stop")
 		job?.cancel()
 		job = null
-		activeGuides.clear()
+		synchronized(activeGuides) { activeGuides.clear() }
 		resetStepState()
 	}
 

--- a/app/src/test/java/com/kimjisub/launchpad/unipack/runner/AutoPlayRunnerTest.kt
+++ b/app/src/test/java/com/kimjisub/launchpad/unipack/runner/AutoPlayRunnerTest.kt
@@ -1,0 +1,103 @@
+package com.kimjisub.launchpad.unipack.runner
+
+import com.kimjisub.launchpad.unipack.UniPack
+import com.kimjisub.launchpad.unipack.struct.AutoPlay
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+class AutoPlayRunnerTest {
+
+	private val uncaught = AtomicReference<Throwable?>(null)
+	private var previousHandler: Thread.UncaughtExceptionHandler? = null
+	private var runner: AutoPlayRunner? = null
+
+	@Before
+	fun setUp() {
+		previousHandler = Thread.getDefaultUncaughtExceptionHandler()
+		Thread.setDefaultUncaughtExceptionHandler { _, e -> uncaught.compareAndSet(null, e) }
+	}
+
+	@After
+	fun tearDown() {
+		runner?.stop()
+		Thread.setDefaultUncaughtExceptionHandler(previousHandler)
+	}
+
+	// SystemClock.elapsedRealtime() is stubbed to 0 in unit tests (returnDefaultValues),
+	// so guides that start after t=0 never expire and stay in activeGuides.
+	private fun autoPlayWithGuides(count: Int): AutoPlay {
+		val elements = ArrayList<AutoPlay.Element>()
+		elements.add(AutoPlay.Element.Delay(10))
+		for (i in 0 until count) {
+			elements.add(AutoPlay.Element.On(i / 8, i % 8, 0, 1))
+			elements.add(AutoPlay.Element.Delay(1))
+		}
+		return AutoPlay(elements)
+	}
+
+	@Test
+	fun stopWhileLeavingPracticeMode_doesNotThrowConcurrentModification() {
+		val guideCount = 64
+		val guidesOn = CountDownLatch(guideCount)
+		val cleanupStarted = CountDownLatch(1)
+		val ended = CountDownLatch(1)
+
+		val unipack = mockk<UniPack>(relaxed = true)
+		every { unipack.autoPlayTable } returns autoPlayWithGuides(guideCount)
+
+		val listener = object : AutoPlayRunner.Listener {
+			override fun onStart() {}
+			override fun onPadTouchOn(x: Int, y: Int) {}
+			override fun onPadTouchOff(x: Int, y: Int) {}
+			override fun onChainChange(c: Int) {}
+			override fun onGuidePadOn(x: Int, y: Int, targetWallTimeMs: Long) {
+				guidesOn.countDown()
+			}
+			override fun onGuidePadOff(x: Int, y: Int) {}
+			override fun onGuideLedUpdate(x: Int, y: Int, velocity: Int) {
+				if (velocity == 0) {
+					cleanupStarted.countDown()
+					// Widen the window in which the runner is iterating activeGuides
+					Thread.sleep(1)
+				}
+			}
+			override fun onGuideChainOn(c: Int) {}
+			override fun onRemoveGuide() {}
+			override fun chainButsRefresh() {}
+			override fun onProgressUpdate(progress: Int) {}
+			override fun onEnd() {
+				ended.countDown()
+			}
+		}
+
+		val runner = AutoPlayRunner(unipack, listener, ChainObserver()).also { runner = it }
+		runner.practiceGuide = true
+		runner.playmode = true
+		runner.launch()
+
+		assertTrue("guides were not activated", guidesOn.await(5, TimeUnit.SECONDS))
+
+		// Same order as PlayActivityViewModel.switchPlayMode(PlayMode.None):
+		// flip the flag, let the runner enter its guide cleanup loop, then stop() from this thread.
+		runner.practiceGuide = false
+		assertTrue("runner did not start guide cleanup", cleanupStarted.await(5, TimeUnit.SECONDS))
+		runner.stop()
+
+		val deadline = System.currentTimeMillis() + 5_000
+		while (ended.count > 0 && uncaught.get() == null && System.currentTimeMillis() < deadline) {
+			Thread.sleep(5)
+		}
+
+		assertNull("runner coroutine crashed: ${uncaught.get()}", uncaught.get())
+		assertEquals("onEnd was not called after stop()", 0, ended.count)
+	}
+}


### PR DESCRIPTION
## What and why

Play vitals (versionCode 109, 20 users / 24 reports in 28 days) report `java.util.ConcurrentModificationException` at `AutoPlayRunner$launch$1.invokeSuspend (AutoPlayRunner.kt:139)` when the user leaves practice mode.

**Cause.** `activeGuides` (`AutoPlayRunner.kt:68`) is a plain `mutableMapOf` with no synchronization. `PlayActivityViewModel.switchPlayMode(PlayMode.None)` sets `runner.practiceGuide = false` (`PlayActivityViewModel.kt:568`) and a few statements later calls `runner.stop()` (`PlayActivityViewModel.kt:573`). In between, the 1 ms runner loop on `Dispatchers.Default` sees the flag flip and enters the "Switched FROM practice mode" loop (`for ((key, _) in activeGuides)`), while `stop()` runs `activeGuides.clear()` on the main thread. `LinkedHashMap` detects the concurrent structural change and throws. The chain-mismatch cleanup and the per-tick expiration loop (`iterator()` + `iter.remove()`) iterate the same map and are exposed to the same `stop()` race.

Iterating a snapshot (`activeGuides.keys.toList()`) only narrows the window: the copy itself iterates the `LinkedHashMap` key set and can still throw if `clear()` lands mid-copy, and it does nothing for the expiration loop.

**Fix.** Guard every `activeGuides` access with `synchronized(activeGuides)`, mirroring the file's existing `synchronized(stepPendingPads)` style, so `stop()` waits for the in-progress iteration instead of invalidating it:

- `AutoPlayRunner.kt:117`, `:136` — clears on launch / switch to practice mode
- `AutoPlayRunner.kt:139-144` — the crash site (switch from practice mode)
- `AutoPlayRunner.kt:177-182` — chain-mismatch cleanup
- `AutoPlayRunner.kt:188` — guide insertion
- `AutoPlayRunner.kt:195-217` — expiration / LED brightness loop
- `AutoPlayRunner.kt:313` — `stop()`

Listener callbacks inside the guarded blocks are all `viewModelScope.launch { ... }` dispatches (non-blocking, no re-entry into the runner), so the main thread blocks in `stop()` for at most one loop body. Behaviour is otherwise unchanged.

## How you tested it

- `./gradlew :app:compileDebugKotlin -q` → exit 0, no output.
- New `app/src/test/java/com/kimjisub/launchpad/unipack/runner/AutoPlayRunnerTest.kt` reproduces the race: 64 active guides, flip `practiceGuide = false`, wait until the runner is inside the cleanup loop, then call `stop()` from the test thread (same order as `switchPlayMode(PlayMode.None)`).
  - Against unpatched `origin/main`: `1 test completed, 1 failed` — `runner coroutine crashed: java.util.ConcurrentModificationException`.
  - With this change: `./gradlew :app:testDebugUnitTest --tests 'com.kimjisub.launchpad.unipack.runner.AutoPlayRunnerTest' -q` → exit 0, `tests="1" failures="0" errors="0"`; re-run 3 more times with `--rerun`, all pass.

## UniPack compatibility

- [x] Existing UniPacks load and play exactly as before

## Related issues

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)
