### PR TITLE
fix(oss-licenses): keep OSS license layouts from resource shrinker

### DIFF
--- a/app/src/main/res/raw/keep.xml
+++ b/app/src/main/res/raw/keep.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- play-services-oss-licenses resolves its layouts with Resources.getIdentifier, so the resource
+     shrinker cannot see them and Settings > Open source licenses crashed with Resource ID #0x0 (#31).
+     All six library layouts are pinned here. -->
 <resources xmlns:tools="http://schemas.android.com/tools"
 	tools:keep="@color/gray3,@color/wb2,@color/wb5,
 		@dimen/text_big,@dimen/text,@dimen/text_small,@dimen/imgbtn,
 		@drawable/chainled,@drawable/ic_edit_24dp,@drawable/ic_sort_asc,@drawable/ic_sort_desc,
 		@drawable/phantom_,
 		@layout/libraries_social_licenses_license,@layout/libraries_social_licenses_license_activity,
-		@layout/libraries_social_licenses_license_menu_activity,@layout/license_menu_activity_loading,
+		@layout/libraries_social_licenses_license_loading,@layout/libraries_social_licenses_license_menu_activity,
+		@layout/license_menu_activity_loading,@layout/license_menu_activity_no_licenses,
 		@mipmap/ic_launcher_round,
 		@string/date_format,@string/delete,@string/edit,
 		@string/ignore,@string/information,@string/languageCode,

--- a/app/src/main/res/raw/keep.xml
+++ b/app/src/main/res/raw/keep.xml
@@ -4,6 +4,8 @@
 		@dimen/text_big,@dimen/text,@dimen/text_small,@dimen/imgbtn,
 		@drawable/chainled,@drawable/ic_edit_24dp,@drawable/ic_sort_asc,@drawable/ic_sort_desc,
 		@drawable/phantom_,
+		@layout/libraries_social_licenses_license,@layout/libraries_social_licenses_license_activity,
+		@layout/libraries_social_licenses_license_menu_activity,@layout/license_menu_activity_loading,
 		@mipmap/ic_launcher_round,
 		@string/date_format,@string/delete,@string/edit,
 		@string/ignore,@string/information,@string/languageCode,


### PR DESCRIPTION
## What and why

Settings > Open source licenses crashed for 25 users on versionCode 109 with `Resources$NotFoundException: Resource ID #0x0` at `Resources.getXml`, called from `com.google.android.gms.oss.licenses.zzp.onComplete` (#31).

**Cause is not the missing raw license files.** The last release bundle (`app/build/outputs/bundle/release/app-release.aab`) already contains `base/res/raw/third_party_licenses` (298 KB) and `third_party_license_metadata`, so the disabled `OssLicensesCleanUp` workaround is unrelated. What is missing are the library's **layouts**. Decompiling `play-services-oss-licenses:17.0.1` shows `zzp.onComplete` doing:

```
Resources.getIdentifier("libraries_social_licenses_license_menu_activity", "layout", pkg)
Resources.getXml(id)   // id == 0 -> NotFoundException: Resource ID #0x0
```

The library resolves its layouts by name string, never through `R.layout.*`. The R8 resource shrinker in use since the AGP 9 migration (`android.nonFinalResIds=true`, `shrinkResources = true`) only traces `R` field and XML references, so the previous release's shrinker report (`app/build/outputs/mapping/release/resources.txt`) says:

```
layout:libraries_social_licenses_license_menu_activity:2131492916 is not reachable.
layout:libraries_social_licenses_license_activity:2131492914 is not reachable.
layout:libraries_social_licenses_license:2131492913 is not reachable.
layout:license_menu_activity_loading:2131492917 is not reachable.
```

The library ships its own `keep_third_party_licenses.xml`, but that only protects the two raw files, not the layouts.

**Fix** (`app/src/main/res/raw/keep.xml:7-8`): add the four name-looked-up layouts to the app's existing `tools:keep` list so the shrinker retains them. `libraries_social_licenses_license_activity` and `libraries_social_licenses_license` are included because `OssLicensesActivity` (the per-license detail screen) and the list adapter look them up the same way and would crash next.

**Why this option and not a launch guard.** The issue's proposed guard (`getIdentifier("third_party_licenses", "raw", ...) != 0`) would pass on the shipped build and the crash would still happen inside the library. A guard on the library's internal layout name would be fragile and would silently hide the screen instead of fixing it. Keeping the resources is the documented mechanism for name-based lookups, is a two-line change with no code path touched, and makes the screen actually work; verified end to end below.

## How you tested it

In a worktree on `origin/main` (`3dbfb57a`):

- `./gradlew :app:compileDebugKotlin -q` -> exit 0, no output (no errors).
- `./gradlew :app:assembleRelease -x uploadCrashlyticsMappingFileRelease -q` -> exit 0. New shrinker report:
  ```
  layout:libraries_social_licenses_license_activity:2131492914 reachable from keep xml file
  layout:license_menu_activity_loading:2131492917 reachable from keep xml file
  layout:libraries_social_licenses_license_menu_activity:2131492916 reachable from keep xml file
  layout:libraries_social_licenses_license:2131492913 reachable from keep xml file
  ```
  `aapt2 dump resources app-release.apk` lists all six `layout/libraries_social_licenses_*` / `license_menu_activity_*` entries plus `raw/third_party_licenses` and `raw/third_party_license_metadata`.
- Installed that release APK on an API 36 emulator (`api36_test`), opened Settings > Open Source License via the UI: `OssLicensesMenuActivity` displays the license list (`Displayed ... OssLicensesMenuActivity ... +122ms`), tapping an entry opens `OssLicensesActivity` with the license text (`+78ms`). `logcat` shows no `FATAL` / `NotFoundException`.
- No unit test: the change is a resource-shrinker keep rule with no Kotlin logic, so there is nothing to exercise from `app/src/test`; the release build plus emulator run above is the verification.

## UniPack compatibility

- [x] Existing UniPacks load and play exactly as before

## Related issues

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)
