### PR TITLE
feat(play): bring back the classic trace log as a setting

### DIFF
--- a/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
@@ -109,6 +109,7 @@ import com.kimjisub.launchpad.midi.MidiConnection.removeController
 import com.kimjisub.launchpad.midi.controller.MidiController
 import com.kimjisub.launchpad.tool.Log
 import com.kimjisub.launchpad.tool.Log.log
+import com.kimjisub.launchpad.tool.TraceLogText
 import com.kimjisub.launchpad.ui.theme.PlayPalette
 import com.kimjisub.launchpad.ui.theme.UniPadTheme
 import com.kimjisub.launchpad.viewmodel.PlayActivityViewModel
@@ -158,6 +159,11 @@ class PlayActivity : BaseActivity() {
 	private lateinit var chainViews: Array<ChainView?>
 	private var traceLogOverlayView: TraceLogOverlayView? = null
 
+	// Classic trace log (numbers on pads): what is drawn right now, so one new tap only touches one pad.
+	private var classicTraceShown = false
+	private var classicTraceChain = -1
+	private var classicTraceCount = 0
+
 	private val audioManager: AudioManager by lazy { getSystemService(AUDIO_SERVICE) as AudioManager }
 
 	private val volumeObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
@@ -190,10 +196,18 @@ class PlayActivity : BaseActivity() {
 		}
 
 		override fun updateTraceLogOverlay() {
-			val overlay = traceLogOverlayView ?: return
 			if (!vm.isTraceLogSequenceInitialized) return
-			val seq = vm.traceLogSequence[vm.chain.value]
-			overlay.setData(ArrayList(seq), vm.unipack.buttonX, vm.unipack.buttonY)
+			val chain = vm.chain.value
+			val seq = vm.traceLogSequence[chain]
+			val buttonX = vm.unipack.buttonX
+			val buttonY = vm.unipack.buttonY
+			if (p.traceLogClassic) {
+				traceLogOverlayView?.setData(emptyList(), buttonX, buttonY)
+				renderClassicTraceLog(chain, seq)
+			} else {
+				clearClassicTraceLog()
+				traceLogOverlayView?.setData(ArrayList(seq), buttonX, buttonY)
+			}
 		}
 
 		override fun showToast(resId: Int) {
@@ -926,6 +940,30 @@ class PlayActivity : BaseActivity() {
 		}
 	}
 
+	/** Classic trace log: prints the 1-based tap order on each pad (Settings > Play). */
+	private fun renderClassicTraceLog(chain: Int, seq: List<Pair<Int, Int>>) {
+		if (!::padViews.isInitialized) return
+		val appendOnly = classicTraceShown && chain == classicTraceChain && seq.size == classicTraceCount + 1
+		if (appendOnly) {
+			val (x, y) = seq.last()
+			padViews.getOrNull(x)?.getOrNull(y)?.appendTraceLog("${seq.size} ")
+		} else {
+			val texts = TraceLogText.perPad(seq, vm.unipack.buttonX, vm.unipack.buttonY)
+			for (x in texts.indices) for (y in texts[x].indices) padViews.getOrNull(x)?.getOrNull(y)?.setTraceLogText(texts[x][y])
+		}
+		classicTraceShown = true
+		classicTraceChain = chain
+		classicTraceCount = seq.size
+	}
+
+	private fun clearClassicTraceLog() {
+		if (!classicTraceShown) return
+		if (::padViews.isInitialized) for (row in padViews) for (pad in row) pad?.setTraceLogText("")
+		classicTraceShown = false
+		classicTraceChain = -1
+		classicTraceCount = 0
+	}
+
 	@SuppressLint("ClickableViewAccessibility")
 	private fun setupPads(buttonSizeX: Int, buttonSizeY: Int) {
 		for (x in 0 until vm.unipack.buttonX) {
@@ -935,6 +973,7 @@ class PlayActivity : BaseActivity() {
 				val view = PadView(this)
 				view.layoutParams = LayoutParams(buttonSizeX, buttonSizeY)
 				view.setBackgroundImageDrawable(theme?.btn)
+				theme?.traceLog?.let { view.setTraceLogTextColor(it) }
 				view.setOnTouchListener { _, event ->
 					when (event?.action) {
 						MotionEvent.ACTION_DOWN -> vm.padTouch(x, y, true)

--- a/app/src/main/java/com/kimjisub/launchpad/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/SettingsActivity.kt
@@ -47,6 +47,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -234,6 +236,7 @@ private fun SettingsScreen(
 	onRestoreClick: () -> Unit = {},
 ) {
 	var selectedCategory by remember { mutableStateOf(initialCategory) }
+	var traceLogClassic by remember { mutableStateOf(prefManager.traceLogClassic) }
 
 	Row(
 		modifier = Modifier
@@ -265,6 +268,11 @@ private fun SettingsScreen(
 					onFcmTokenCopy = onFcmTokenCopy,
 					onCommunityItemClick = onCommunityItemClick,
 					onReconnectClick = onReconnectClick,
+					traceLogClassic = traceLogClassic,
+					onTraceLogClassicChange = {
+						prefManager.traceLogClassic = it
+						traceLogClassic = it
+					},
 				)
 
 				SettingsCategory.STORAGE -> StorageContent(
@@ -468,6 +476,8 @@ private fun InfoContent(
 	onFcmTokenCopy: () -> Unit,
 	onCommunityItemClick: (action: String, url: String) -> Unit,
 	onReconnectClick: () -> Unit = {},
+	traceLogClassic: Boolean = false,
+	onTraceLogClassicChange: (Boolean) -> Unit = {},
 ) {
 	var showCommunityDialog by remember { mutableStateOf(false) }
 
@@ -484,6 +494,26 @@ private fun InfoContent(
 			SettingsRow(
 				title = stringResource(R.string.reconnect_launchpad),
 				onClick = onReconnectClick,
+			)
+		}
+
+		Spacer(Modifier.height(24.dp))
+
+		// -- Play section --
+		SectionLabel(stringResource(R.string.settings_play))
+
+		SettingsCard {
+			SettingsRow(
+				title = stringResource(R.string.trace_log_classic),
+				subtitle = stringResource(R.string.trace_log_classic_desc),
+				onClick = { onTraceLogClassicChange(!traceLogClassic) },
+				trailing = {
+					Switch(
+						checked = traceLogClassic,
+						onCheckedChange = onTraceLogClassicChange,
+						colors = SwitchDefaults.colors(checkedTrackColor = Accent),
+					)
+				},
 			)
 		}
 

--- a/app/src/main/java/com/kimjisub/launchpad/manager/PreferenceManager.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/manager/PreferenceManager.kt
@@ -61,6 +61,15 @@ class PreferenceManager(
 			}
 		}
 
+	/** Classic trace log: tap order as numbers on each pad (the pre-4.1 look) instead of the line-and-dot overlay. */
+	var traceLogClassic: Boolean
+		get() = pref.getBoolean(KEY_TRACE_LOG_CLASSIC, false)
+		set(value) {
+			pref.edit {
+				putBoolean(KEY_TRACE_LOG_CLASSIC, value)
+			}
+		}
+
 	var downloadStoragePath: String?
 		get() = pref.getString(KEY_DOWNLOAD_STORAGE_PATH, null)
 		set(value) {
@@ -88,5 +97,6 @@ class PreferenceManager(
 		private const val KEY_SORT_ORDER = "SortOrder"
 		private const val KEY_DOWNLOAD_STORAGE_PATH = "download_storage_path"
 		private const val KEY_BACKUP_SAF_URI = "backup_saf_uri"
+		private const val KEY_TRACE_LOG_CLASSIC = "TraceLogClassic"
 	}
 }

--- a/app/src/main/java/com/kimjisub/launchpad/tool/TraceLogText.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/tool/TraceLogText.kt
@@ -1,0 +1,17 @@
+package com.kimjisub.launchpad.tool
+
+/** Text for the classic trace log, where each pad shows the order of every tap on it. */
+object TraceLogText {
+	/**
+	 * Returns one string per pad ([buttonX][buttonY]): the 1-based index of every tap on that pad,
+	 * each followed by a space ("1 5 "), which is the format the pre-4.1 trace log used.
+	 * Taps outside the grid are ignored.
+	 */
+	fun perPad(sequence: List<Pair<Int, Int>>, buttonX: Int, buttonY: Int): Array<Array<String>> {
+		val builders = Array(buttonX) { Array(buttonY) { StringBuilder() } }
+		sequence.forEachIndexed { index, (x, y) ->
+			if (x in 0 until buttonX && y in 0 until buttonY) builders[x][y].append(index + 1).append(' ')
+		}
+		return Array(buttonX) { x -> Array(buttonY) { y -> builders[x][y].toString() } }
+	}
+}

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -158,6 +158,9 @@
 	<string name="theme_description">This is Default UniPad Theme</string>
 	<string name="theme_author">UniPad dev.</string>
 	<string name="settings_device">기기</string>
+	<string name="settings_play">연주</string>
+	<string name="trace_log_classic">예전 방식 순서 기록</string>
+	<string name="trace_log_classic_desc">선과 점 대신 각 패드에 누른 순서를 숫자로 표시합니다</string>
 	<string name="settings_info">정보</string>
 	<string name="settings_storage">저장소</string>
 	<string name="settings_theme">테마</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,6 +169,9 @@
 	<string name="theme_description">This is Default UniPad Theme</string>
 	<string name="theme_author">UniPad dev.</string>
 	<string name="settings_device">Device</string>
+	<string name="settings_play">Play</string>
+	<string name="trace_log_classic">Classic trace log</string>
+	<string name="trace_log_classic_desc">Show the tap order as numbers on each pad instead of lines and dots</string>
 	<string name="settings_info">Information</string>
 	<string name="settings_storage">Storage</string>
 	<string name="settings_theme">Theme</string>

--- a/app/src/test/java/com/kimjisub/launchpad/tool/TraceLogTextTest.kt
+++ b/app/src/test/java/com/kimjisub/launchpad/tool/TraceLogTextTest.kt
@@ -1,0 +1,37 @@
+package com.kimjisub.launchpad.tool
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TraceLogTextTest {
+
+	@Test
+	fun emptySequence_givesEmptyTextOnEveryPad() {
+		val texts = TraceLogText.perPad(emptyList(), 2, 3)
+
+		assertEquals(2, texts.size)
+		assertEquals(3, texts[0].size)
+		for (row in texts) for (text in row) assertEquals("", text)
+	}
+
+	@Test
+	fun tapsAreNumberedFromOne_andRepeatedPadsAccumulate() {
+		val seq = listOf(Pair(0, 0), Pair(1, 2), Pair(0, 0), Pair(1, 1))
+
+		val texts = TraceLogText.perPad(seq, 2, 3)
+
+		assertEquals("1 3 ", texts[0][0])
+		assertEquals("2 ", texts[1][2])
+		assertEquals("4 ", texts[1][1])
+		assertEquals("", texts[0][1])
+	}
+
+	@Test
+	fun tapsOutsideTheGrid_areIgnoredButStillCounted() {
+		val seq = listOf(Pair(5, 5), Pair(0, 0), Pair(-1, 0))
+
+		val texts = TraceLogText.perPad(seq, 2, 2)
+
+		assertEquals("2 ", texts[0][0])
+	}
+}


### PR DESCRIPTION
## What and why

4.1 replaced the per-pad tap numbers with a line-and-dot overlay (`dbe783be`). Two Play reviews on 4.1.3 (versionCode 109) say the old numbers were easier to memorize a pattern with. This adds **Settings > Play > Classic trace log** (off by default). When on, each pad shows the 1-based order of every tap on it, exactly the pre-4.1 format, and the overlay is hidden.

- `PreferenceManager.traceLogClassic` (key `TraceLogClassic`, default `false`)
- `SettingsActivity`: new Play section with a Switch row (`app/src/main/java/com/kimjisub/launchpad/activity/SettingsActivity.kt`)
- `PlayActivity.updateTraceLogOverlay()` branches on the setting. A single new tap appends only to that pad; a chain switch or a long-press reset redraws the grid. The theme's trace color is applied to pads again (it was dropped in `dbe783be` along with the text path).
- `TraceLogText.perPad()`: pure helper turning the tap sequence into per-pad text, so the format is unit-tested.

## How you tested it

```
./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --tests 'com.kimjisub.launchpad.tool.TraceLogTextTest' -q
# exit 0; JUnit: tests="3" skipped="0" failures="0" errors="0"
```

Not run on a device in this PR. The overlay path is unchanged when the setting is off (default), so existing users see no difference until they opt in.

## UniPack compatibility
- [x] Existing UniPacks load and play exactly as before

## Related issues
Play reviews 9468840c and 776bf62b (2026-09-06 window), tracked in the private ops repo as D-004.
