### PR TITLE
fix(midi,settings): guard the openDevice callback and the FCM token listener

### DIFF
--- a/app/src/main/java/com/kimjisub/launchpad/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/SettingsActivity.kt
@@ -175,9 +175,17 @@ class SettingsActivity : AppCompatActivity() {
 
 	private fun copyFcmToken() {
 		try {
-			FirebaseMessaging.getInstance().token.addOnCompleteListener {
-				putClipboard(it.result)
-				Snackbar.make(findViewById(android.R.id.content), R.string.copied, Snackbar.LENGTH_SHORT).show()
+			FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+				// task.result throws when the token fetch failed (Crashlytics 2f4ba056:
+				// IOException TOO_MANY_REGISTRATIONS on 4.1.4), so check first.
+				if (task.isSuccessful) {
+					putClipboard(task.result)
+					Snackbar.make(findViewById(android.R.id.content), R.string.copied, Snackbar.LENGTH_SHORT).show()
+				} else {
+					val e = task.exception
+					Log.err("FCM token fetch failed", e ?: IllegalStateException("no exception"))
+					Snackbar.make(findViewById(android.R.id.content), e?.message ?: "FCM token unavailable", Snackbar.LENGTH_SHORT).show()
+				}
 			}
 		} catch (e: IllegalStateException) {
 			Log.err("FCM token copy failed", e)

--- a/app/src/main/java/com/kimjisub/launchpad/midi/MidiConnection.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/MidiConnection.kt
@@ -414,43 +414,56 @@ object MidiConnection {
 
 		try {
 			manager.openDevice(targetInfo, { device ->
-				if (device != null) {
-					midiDevice = device
-					Log.midiDetail("MIDI API: Device opened successfully")
-
-					// Open all input ports and send SysEx
-					for (portInfo in targetInfo.ports) {
-						if (portInfo.type == MidiDeviceInfo.PortInfo.TYPE_INPUT) {
-							val port = device.openInputPort(portInfo.portNumber)
-							if (port != null) {
-								midiInputPorts[portInfo.portNumber] = port
-								Log.midiDetail("MIDI API: Opened input port ${portInfo.portNumber} (${portInfo.name})")
-							}
-						}
-					}
-
-					// Send SysEx to ALL input ports (port names are empty, we don't know which is DAW)
-					val initData = driver.getInitSysEx()
-					if (initData != null && midiInputPorts.isNotEmpty()) {
-						val (messages, _) = initData
-						for ((portNum, _) in midiInputPorts) {
-							Log.midiDetail("MIDI API: Sending init SysEx (${messages.size} messages) to port $portNum")
-							sendViaMidiApi(messages, portNum)
-						}
-					}
-
-					// Delay to ensure SysEx is flushed before closing ports
-					Handler(Looper.getMainLooper()).postDelayed({
-						closeMidiApi()
-						claimUsbAndStart()
-					}, 500)
-				} else {
-					Log.midiDetail("MIDI API: Failed to open device, claiming USB interface directly")
+				// Runs later on the main Handler, outside the try below: a framework exception here
+				// (Crashlytics 9b99a871: SecurityException from openInputPort on Android 16) must fall
+				// back the same way a null device does.
+				try {
+					onMidiApiDeviceOpened(device, targetInfo)
+				} catch (e: RuntimeException) {
+					Log.err("MIDI API: device callback failed, claiming USB interface directly", e)
+					closeMidiApi()
 					claimUsbAndStart()
 				}
 			}, Handler(Looper.getMainLooper()))
 		} catch (e: RuntimeException) {
 			Log.err("MIDI API: openDevice failed, claiming USB interface directly", e)
+			claimUsbAndStart()
+		}
+	}
+
+	private fun onMidiApiDeviceOpened(device: MidiDevice?, targetInfo: MidiDeviceInfo) {
+		if (device != null) {
+			midiDevice = device
+			Log.midiDetail("MIDI API: Device opened successfully")
+
+			// Open all input ports and send SysEx
+			for (portInfo in targetInfo.ports) {
+				if (portInfo.type == MidiDeviceInfo.PortInfo.TYPE_INPUT) {
+					val port = device.openInputPort(portInfo.portNumber)
+					if (port != null) {
+						midiInputPorts[portInfo.portNumber] = port
+						Log.midiDetail("MIDI API: Opened input port ${portInfo.portNumber} (${portInfo.name})")
+					}
+				}
+			}
+
+			// Send SysEx to ALL input ports (port names are empty, we don't know which is DAW)
+			val initData = driver.getInitSysEx()
+			if (initData != null && midiInputPorts.isNotEmpty()) {
+				val (messages, _) = initData
+				for ((portNum, _) in midiInputPorts) {
+					Log.midiDetail("MIDI API: Sending init SysEx (${messages.size} messages) to port $portNum")
+					sendViaMidiApi(messages, portNum)
+				}
+			}
+
+			// Delay to ensure SysEx is flushed before closing ports
+			Handler(Looper.getMainLooper()).postDelayed({
+				closeMidiApi()
+				claimUsbAndStart()
+			}, 500)
+		} else {
+			Log.midiDetail("MIDI API: Failed to open device, claiming USB interface directly")
 			claimUsbAndStart()
 		}
 	}


### PR DESCRIPTION
## What and why

Two crash clusters that only Crashlytics shows (read via the Firebase CLI MCP server, 28 days to 2026-09-06):

- **#49** `MidiConnection.initMidiApiDevice$lambda$1`: `SecurityException - Binder invocation to an incorrect interface` (62 crashes, 4 users, Xiaomi on Android 16). The `openDevice` completion callback runs later on the main Handler, outside the `try` that #41 added around `openDevice` itself, so a framework exception from `openInputPort` still killed `UsbMidiHandlerActivity`. The callback body is now `onMidiApiDeviceOpened(device, targetInfo)` wrapped in `try/catch (RuntimeException)`; on failure it calls `closeMidiApi()` and `claimUsbAndStart()`, the same fallback the null-device branch takes.
- **#50** `SettingsActivity.copyFcmToken`: `task.result` throws `RuntimeExecutionException` when the token fetch failed (`IOException TOO_MANY_REGISTRATIONS`, 2 users on 4.1.4 in the first hours of the rollout). Now checks `task.isSuccessful` and shows the error in the Snackbar.

## How you tested it

`./gradlew :app:compileDebugKotlin -q` -> exit 0. No unit test: both paths need the Android framework (`MidiManager` callback, Play services `Task`); the guards only widen existing fallbacks.

## UniPack compatibility
- [x] Existing UniPacks load and play exactly as before

## Related issues
Fixes #49, Fixes #50. Follow-up to #41 (#35).
