### PR TITLE
fix: guard six Crashlytics clusters, stop buffering downloads in the HTTP logger

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,11 @@ android {
 			manifestPlaceholders = [appName: "@string/app_name"]
 			signingConfig = signingConfigs.release
 			debuggable = false
+			// Ship native debug symbols inside the bundle so Play vitals can resolve
+			// liboboe / libunipad_audio frames (#37).
+			ndk {
+				debugSymbolLevel = 'FULL'
+			}
 
 			minifyEnabled = true
 			shrinkResources = true

--- a/app/src/main/cpp/AudioEngine.cpp
+++ b/app/src/main/cpp/AudioEngine.cpp
@@ -16,6 +16,8 @@ AudioEngine::~AudioEngine() {
 }
 
 bool AudioEngine::start() {
+    stop();
+    stopping_ = false;
     oboe::AudioStreamBuilder builder;
     builder.setDirection(oboe::Direction::Output)
            ->setPerformanceMode(oboe::PerformanceMode::LowLatency)
@@ -40,6 +42,7 @@ bool AudioEngine::start() {
     if (result != oboe::Result::OK) {
         LOGE("Failed to start stream: %s", oboe::convertToText(result));
         stream_->close();
+        stream_.reset();
         return false;
     }
 
@@ -48,10 +51,14 @@ bool AudioEngine::start() {
 }
 
 void AudioEngine::stop() {
-    if (stream_) {
-        stream_->requestStop();
-        stream_->close();
-        stream_.reset();
+    // Flag first so a callback that is already scheduled returns Stop instead of touching
+    // the voices while the stream is torn down.
+    stopping_ = true;
+    auto stream = stream_;
+    stream_.reset();
+    if (stream) {
+        stream->requestStop();
+        stream->close();
     }
 }
 
@@ -133,6 +140,8 @@ oboe::DataCallbackResult AudioEngine::onAudioReady(
 
     auto* output = static_cast<int16_t*>(audioData);
     std::memset(output, 0, numFrames * 2 * sizeof(int16_t)); // stereo
+
+    if (stopping_.load()) return oboe::DataCallbackResult::Stop;
 
     std::lock_guard<std::mutex> lock(voiceMutex_);
 

--- a/app/src/main/cpp/AudioEngine.h
+++ b/app/src/main/cpp/AudioEngine.h
@@ -55,5 +55,6 @@ private:
     ActiveVoice voices_[MAX_VOICES];
     SoundBank soundBank_;
     std::atomic<int> nextStopKey_{1};
+    std::atomic<bool> stopping_{false};
     int outputSampleRate_ = 48000;
 };

--- a/app/src/main/cpp/jni_bridge.cpp
+++ b/app/src/main/cpp/jni_bridge.cpp
@@ -6,16 +6,19 @@
 #define LOG_TAG "UniPadAudioJNI"
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
 
+// One engine for the life of the process. It used to be destroyed on every stop and
+// re-created on start; a callback still in flight on some low-end devices then hit a
+// destroyed mutex and the process aborted (Play vitals: SIGABRT in libc++ under liboboe,
+// unipad-android #37). Streams are opened and closed, the engine object stays.
 static std::unique_ptr<AudioEngine> sEngine;
 
 extern "C" {
 
 JNIEXPORT jboolean JNICALL
 Java_com_kimjisub_launchpad_audio_OboeAudioEngine_nativeStart(JNIEnv*, jobject) {
-    if (sEngine) {
-        sEngine->stop();
+    if (!sEngine) {
+        sEngine = std::make_unique<AudioEngine>();
     }
-    sEngine = std::make_unique<AudioEngine>();
     return sEngine->start() ? JNI_TRUE : JNI_FALSE;
 }
 
@@ -23,7 +26,6 @@ JNIEXPORT void JNICALL
 Java_com_kimjisub_launchpad_audio_OboeAudioEngine_nativeStop(JNIEnv*, jobject) {
     if (sEngine) {
         sEngine->stop();
-        sEngine.reset();
     }
 }
 

--- a/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
@@ -1024,7 +1024,8 @@ class PlayActivity : BaseActivity() {
 	// region LED rendering
 
 	private fun setLedUI(x: Int, y: Int) {
-		val pad = padViews[x][y] ?: return
+		if (!::padViews.isInitialized) return
+		val pad = padViews.getOrNull(x)?.getOrNull(y) ?: return
 		val item = vm.channelManager.get(x, y)
 		if (item != null) {
 			when (item.channel) {
@@ -1042,7 +1043,8 @@ class PlayActivity : BaseActivity() {
 	}
 
 	private fun setLedUIChain(y: Int) {
-		if (y !in chainViews.indices) return
+		// The volume observer can fire before start() allocates chainViews (Crashlytics 89bc2683).
+		if (!::chainViews.isInitialized || y !in chainViews.indices) return
 		val item = vm.channelManager.get(-1, y)
 		val circle = chainViews[y] ?: return
 		if (theme?.isChainLed == true) {

--- a/app/src/main/java/com/kimjisub/launchpad/api/BaseApiService.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/api/BaseApiService.kt
@@ -92,7 +92,10 @@ object BaseApiService {
 
 	fun <T> createRetrofitService(baseUrl: String, serviceClass: Class<T>): T {
 		val httpLoggingInterceptor = HttpLoggingInterceptor { message -> Log.network(message) }
-		httpLoggingInterceptor.level = Level.BODY
+		// Never BODY: the same client downloads UniPack ZIPs, and BODY buffers the whole
+		// response in memory before logging it (Crashlytics b1f34473 / 0a626898: OOM in
+		// okio.Segment during UniPackDownloader).
+		httpLoggingInterceptor.level = Level.HEADERS
 		val client = okHttpClientBuilder
 			.addInterceptor(httpLoggingInterceptor)
 			.build()

--- a/app/src/main/java/com/kimjisub/launchpad/midi/driver/LaunchpadMK2.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/driver/LaunchpadMK2.kt
@@ -26,9 +26,11 @@ class LaunchpadMK2 : DriverRef() {
 		if (cmd == 9) {
 			val x = 9 - note / 10
 			val y = note % 10
-			if (y in 1..8)
+			// Notes 91..98 (x = 0) are the top row on some firmwares and would map to pad row -1
+			// (Crashlytics f2a35391: ArrayIndexOutOfBounds index=-1 in PlayActivity.setLedUI).
+			if (x in 1..8 && y in 1..8)
 				onPadTouch(x - 1, y - 1, velocity != 0, velocity)
-			else if (y == 9) {
+			else if (y == 9 && x in 1..8) {
 				onChainTouch(x - 1, velocity != 0)
 				onFunctionKeyTouch(x - 1 + 8, velocity != 0)
 			}

--- a/app/src/main/java/com/kimjisub/launchpad/tool/splitties/Browse.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/tool/splitties/Browse.kt
@@ -1,11 +1,21 @@
 package com.kimjisub.launchpad.tool.splitties
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+import android.widget.Toast
 import androidx.core.net.toUri
+import com.kimjisub.launchpad.R
+import com.kimjisub.launchpad.tool.Log
 
 fun android.content.Context.browse(link: String) {
 	val myIntent = Intent(Intent.ACTION_VIEW, link.toUri())
 	myIntent.addFlags(FLAG_ACTIVITY_NEW_TASK)
-	startActivity(myIntent)
+	try {
+		startActivity(myIntent)
+	} catch (e: ActivityNotFoundException) {
+		// Devices without a browser or YouTube app (Crashlytics d783e2d5)
+		Log.err("no activity for $link", e)
+		Toast.makeText(this, R.string.no_app_for_link, Toast.LENGTH_SHORT).show()
+	}
 }

--- a/app/src/main/java/com/kimjisub/launchpad/unipack/UniPack.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/unipack/UniPack.kt
@@ -121,6 +121,7 @@ abstract class UniPack {
 	fun soundPush(c: Int, x: Int, y: Int, num: Int) {
 		try {
 			val sounds = soundTable?.get(c)?.get(x)?.get(y) ?: return
+			if (sounds.isEmpty()) return
 			val targetNum = num % sounds.size
 			if (sounds[0].num != targetNum)
 				while (true) {
@@ -160,6 +161,7 @@ abstract class UniPack {
 	fun ledPush(c: Int, x: Int, y: Int, num: Int) {
 		try {
 			val leds = ledAnimationTable?.get(c)?.get(x)?.get(y) ?: return
+			if (leds.isEmpty()) return  // Crashlytics 313e518c: divide by zero on an empty cell
 			val targetNum = num % leds.size
 			if (leds[0].num != targetNum)
 				while (true) {

--- a/app/src/main/java/com/kimjisub/launchpad/unipack/runner/LedRunner.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/unipack/runner/LedRunner.kt
@@ -51,6 +51,12 @@ class LedRunner(
 					while (true) {
 						// Counting Up Loop Progress
 						val ledEvents = state.ledAnimation?.ledEvents ?: break
+						// An empty keyLED file gives an animation with no events; with loop 0 the old code
+						// spun into ledEvents[0] on an empty list (Crashlytics a1376611).
+						if (ledEvents.isEmpty()) {
+							state.isPlaying = false
+							break
+						}
 						if (state.index >= ledEvents.size) {
 							state.loopProgress++
 							state.index = 0
@@ -103,8 +109,8 @@ class LedRunner(
 										chain.value = event.chain
 									}
 								}
-							} catch (ex: ArrayIndexOutOfBoundsException) {
-								Log.err("LED event ArrayIndexOutOfBounds", ex)
+							} catch (ex: IndexOutOfBoundsException) {
+								Log.err("LED event index out of bounds", ex)
 							}
 						} else break
 						state.index++

--- a/app/src/main/java/com/kimjisub/launchpad/viewmodel/PlayActivityViewModel.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/viewmodel/PlayActivityViewModel.kt
@@ -382,6 +382,12 @@ class PlayActivityViewModel(
 	// pad, chain
 
 	fun padTouch(x: Int, y: Int, upDown: Boolean) {
+		// A driver can hand over a coordinate outside the pack grid; the UI callbacks run later
+		// on the main thread, outside the catch below, so reject it here.
+		if (!::unipack.isInitialized || x !in 0 until unipack.buttonX || y !in 0 until unipack.buttonY) {
+			Log.err("padTouch out of range: ($x, $y)")
+			return
+		}
 		try {
 			if (upDown) {
 				if (autoPlayRunner?.stepMode == true) {

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -113,6 +113,7 @@
 	<string name="importComplete">불러오기 성공!</string>
 	<string name="importFailed">불러오기 실패…</string>
 	<string name="copied">클립보드에 복사되었습니다.</string>
+	<string name="no_app_for_link">이 링크를 열 수 있는 앱이 없습니다.</string>
 	<string name="skinMemoryErr">스킨을 불러오는 도중 메모리 문제가 발생하였습니다.\n앱을 재시작합니다.</string>
 	<string name="skinErr">스킨에 문제가 있습니다.\n스킨을 초기화합니다.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,7 @@
 	<string name="importComplete">Analysis complete!</string>
 	<string name="importFailed">Failed to analyze…</string>
 	<string name="copied">Copied to clipboard.</string>
+	<string name="no_app_for_link">No app on this device can open this link.</string>
 	<string name="skinMemoryErr">Failed to apply skin.\nRestart app.</string>
 	<string name="skinErr">Failed to apply skin.\nReset skin.</string>
 

--- a/app/src/test/java/com/kimjisub/launchpad/midi/driver/LaunchpadMK2Test.kt
+++ b/app/src/test/java/com/kimjisub/launchpad/midi/driver/LaunchpadMK2Test.kt
@@ -42,6 +42,14 @@ class LaunchpadMK2Test {
 		verify { receiveListener.onPadTouch(0, 0, false, 0) }
 	}
 
+	@Test
+	fun getSignal_noteAboveTheGrid_isIgnored() {
+		// note=95: x=9-9=0, y=5 -> would be pad(-1, 4); some firmwares send the top row this way
+		driver.getSignal(cmd = 9, sig = 0, note = 95, velocity = 100)
+		verify(exactly = 0) { receiveListener.onPadTouch(any(), any(), any(), any()) }
+		verify(exactly = 0) { receiveListener.onChainTouch(any(), any()) }
+	}
+
 	// --- getSignal: chain and function keys ---
 
 	@Test


### PR DESCRIPTION
## What and why

Fixes #52 (table of the six Crashlytics clusters with ids, counts and causes is there). Each guard sits both where the bad value is produced and where it is consumed:

- `LaunchpadMK2.getSignal`: notes 91..98 (x = 0) were mapped to pad row -1. `PlayActivityViewModel.padTouch` now also rejects any coordinate outside the pack grid, because the UI callbacks run later via `lifecycleScope.launch`, outside the existing catch. `setLedUI` / `setLedUIChain` tolerate uninitialized `padViews` / `chainViews` (the volume observer fires before `start()`).
- `LedRunner.loop`: an animation with zero events now stops; the catch covers `IndexOutOfBoundsException` (ArrayList throws that, not the Array subclass).
- `UniPack.ledPush/soundPush(num)`: return on an empty cell before `% size`.
- `Browse.kt`: `ActivityNotFoundException` shows "No app on this device can open this link." (new string, en + ko).
- `BaseApiService`: logging level HEADERS. BODY made OkHttp buffer whole UniPack ZIPs before logging them, which is the OOM cluster. Rule recorded as R-201 in the workspace repo.
- `app/build.gradle`: `ndk.debugSymbolLevel = 'FULL'` for release, so the liboboe SIGABRT in #37 resolves in Play vitals next time.
- `jni_bridge.cpp` / `AudioEngine`: the engine is created once per process and only the Oboe stream is opened/closed; `stop()` flags `stopping_` first so an in-flight callback returns `Stop`. Before, every stop destroyed the engine (and its mutex) while a callback could still be running on some low-end devices, which is a plausible path to the libc++ abort in #37. Unconfirmed until symbols arrive; behaviour on the happy path is unchanged.

## How you tested it

```
./gradlew :app:compileDebugKotlin :app:externalNativeBuildDebug :app:testDebugUnitTest --tests 'com.kimjisub.launchpad.midi.driver.LaunchpadMK2Test' -q
# EXIT=0; LaunchpadMK2Test: tests="14" failures="0" errors="0" (new: getSignal_noteAboveTheGrid_isIgnored)
# libunipad_audio.so rebuilt for arm64-v8a, armeabi-v7a, x86
```

No device run. The LedRunner and volume-observer paths need the Android framework; the guards only add early returns.

## UniPack compatibility
- [x] Existing UniPacks load and play exactly as before

## Related issues
Fixes #52. Related #37 (symbols + engine lifecycle), #22.
