### PR TITLE
fix(workspace): fall back to internal storage when the app external dir is unavailable

### DIFF
--- a/app/src/main/java/com/kimjisub/launchpad/manager/WorkspaceManager.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/manager/WorkspaceManager.kt
@@ -44,6 +44,20 @@ class WorkspaceManager(val context: Context) : KoinComponent {
 						appWorkspace
 					)
 				)
+			} ?: run {
+				// No app-specific external dir (primary volume unmounted or not ready): fall back
+				// to the internal app folder so the list is never empty. downloadWorkspace and
+				// validateWorkspace index [0] and would otherwise throw (#46).
+				val internalWorkspace = File(context.filesDir, "UniPack")
+				if (!internalWorkspace.exists()) {
+					internalWorkspace.mkdirs()
+				}
+				uniPackWorkspaces.add(
+					Workspace(
+						context.getString(R.string.workspace_internal_storage),
+						internalWorkspace
+					)
+				)
 			}
 
 			// External SD cards only (skip internal storage which duplicates App Storage)

--- a/app/src/test/java/com/kimjisub/launchpad/manager/WorkspaceManagerTest.kt
+++ b/app/src/test/java/com/kimjisub/launchpad/manager/WorkspaceManagerTest.kt
@@ -127,7 +127,7 @@ class WorkspaceManagerTest {
 	}
 
 	@Test
-	fun availableWorkspaces_includesInternalStorage() {
+	fun availableWorkspaces_fallsBackToInternalStorageWhenAppExternalDirIsUnavailable() {
 		val internalDir = File(tempDir, "internal")
 		internalDir.mkdirs()
 
@@ -138,10 +138,21 @@ class WorkspaceManagerTest {
 		val manager = WorkspaceManager(mockContext)
 		val workspaces = manager.availableWorkspaces
 
-		assertTrue(
-			"Should contain 'Internal Storage' workspace",
-			workspaces.any { it.name == "Internal Storage" }
-		)
+		assertEquals("Internal Storage", workspaces.first().name)
+		assertEquals(File(internalDir, "UniPack"), workspaces.first().file)
+	}
+
+	@Test
+	fun availableWorkspaces_doesNotAddInternalStorageWhenAppExternalDirExists() {
+		val appDir = File(tempDir, "app_external")
+		appDir.mkdirs()
+
+		every { mockContext.getExternalFilesDir(null) } returns appDir
+		every { mockContext.getExternalFilesDirs("UniPack") } returns arrayOf()
+
+		val manager = WorkspaceManager(mockContext)
+
+		assertTrue(manager.availableWorkspaces.none { it.name == "Internal Storage" })
 	}
 
 	@Test


### PR DESCRIPTION
## What and why

Fixes #46. `availableWorkspaces` skipped internal storage on purpose (it duplicates App Storage), so the old test `availableWorkspaces_includesInternalStorage` asserted behaviour that no code produced. The real gap behind it: when `getExternalFilesDir(null)` is null (primary volume unmounted or not ready) the list could be empty and `downloadWorkspace` / `validateWorkspace` index `[0]` (reviewer nit on #40). The internal app folder (`filesDir/UniPack`) now takes App Storage's place only in that case.

## How you tested it

```
./gradlew :app:testDebugUnitTest --tests 'com.kimjisub.launchpad.manager.WorkspaceManagerTest' -q
# tests="11" failures="0" errors="0"  (was 10 with 1 failure on main)
```

New: `availableWorkspaces_fallsBackToInternalStorageWhenAppExternalDirIsUnavailable`, `availableWorkspaces_doesNotAddInternalStorageWhenAppExternalDirExists`.

## UniPack compatibility
- [x] Existing UniPacks load and play exactly as before

## Related issues
Fixes #46. Follow-up to #40 (#30).