### PR TITLE
feat(play): Slide Mode setting, dragging a finger across pads plays them

### DIFF
--- a/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
@@ -95,6 +95,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.kimjisub.design.view.ChainView
 import com.kimjisub.design.view.PadView
+import com.kimjisub.design.view.SlideTouchOverlayView
 import com.kimjisub.design.view.TraceLogOverlayView
 import com.kimjisub.launchpad.R
 import com.kimjisub.launchpad.R.string
@@ -158,6 +159,7 @@ class PlayActivity : BaseActivity() {
 	private lateinit var padViews: Array<Array<PadView?>>
 	private lateinit var chainViews: Array<ChainView?>
 	private var traceLogOverlayView: TraceLogOverlayView? = null
+	private var slideTouchOverlayView: SlideTouchOverlayView? = null
 
 	// Classic trace log (numbers on pads): what is drawn right now, so one new tap only touches one pad.
 	private var classicTraceShown = false
@@ -521,6 +523,14 @@ class PlayActivity : BaseActivity() {
 								} },
 								modifier = Modifier.wrapContentSize()
 							)
+							// Slide Mode layer: GONE unless the setting is on, so pads keep their own touches
+							AndroidView(
+								factory = { ctx -> SlideTouchOverlayView(ctx).also { overlay ->
+									overlay.visibility = View.GONE
+									slideTouchOverlayView = overlay
+								} },
+								modifier = Modifier.wrapContentSize()
+							)
 							if (!vm.isOptionWindowVisible) {
 								ChromeColumn()
 							} else {
@@ -538,13 +548,17 @@ class PlayActivity : BaseActivity() {
 						val overlayPlaceable = measurables[5].measure(
 							Constraints.fixed(padPlaceable.width, padPlaceable.height)
 						)
-						val chromePlaceable = measurables[6].measure(unconstrained)
+						val slidePlaceable = measurables[6].measure(
+							Constraints.fixed(padPlaceable.width, padPlaceable.height)
+						)
+						val chromePlaceable = measurables[7].measure(unconstrained)
 						layout(constraints.maxWidth, constraints.maxHeight) {
 							// Pads centered in the area excluding the right chrome strip
 							val padX = ((constraints.maxWidth - chromeStripPx) - padPlaceable.width) / 2
 							val padY = (constraints.maxHeight - padPlaceable.height) / 2
 							padPlaceable.place(padX, padY)
 							overlayPlaceable.place(padX, padY)
+							slidePlaceable.place(padX, padY)
 							leftPlaceable.place(padX - leftPlaceable.width, padY + (padPlaceable.height - leftPlaceable.height) / 2)
 							rightPlaceable.place(padX + padPlaceable.width, padY + (padPlaceable.height - rightPlaceable.height) / 2)
 							topPlaceable.place(padX + (padPlaceable.width - topPlaceable.width) / 2, padY - topPlaceable.height)
@@ -929,6 +943,11 @@ class PlayActivity : BaseActivity() {
 			chainsLeftContainer?.removeAllViews()
 			setupPads(buttonSizeX, buttonSizeY)
 			setupChains(buttonSizeMin)
+			slideTouchOverlayView?.apply {
+				setGrid(vm.unipack.buttonX, vm.unipack.buttonY)
+				listener = { x, y, down -> vm.padTouch(x, y, down) }
+				visibility = if (p.slideMode) View.VISIBLE else View.GONE
+			}
 			vm.traceLogInit()
 			vm.proLightMode(vm.scbProLightMode.isChecked())
 			vm.uiLoaded = true

--- a/app/src/main/java/com/kimjisub/launchpad/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/SettingsActivity.kt
@@ -245,6 +245,7 @@ private fun SettingsScreen(
 ) {
 	var selectedCategory by remember { mutableStateOf(initialCategory) }
 	var traceLogClassic by remember { mutableStateOf(prefManager.traceLogClassic) }
+	var slideMode by remember { mutableStateOf(prefManager.slideMode) }
 
 	Row(
 		modifier = Modifier
@@ -280,6 +281,11 @@ private fun SettingsScreen(
 					onTraceLogClassicChange = {
 						prefManager.traceLogClassic = it
 						traceLogClassic = it
+					},
+					slideMode = slideMode,
+					onSlideModeChange = {
+						prefManager.slideMode = it
+						slideMode = it
 					},
 				)
 
@@ -486,6 +492,8 @@ private fun InfoContent(
 	onReconnectClick: () -> Unit = {},
 	traceLogClassic: Boolean = false,
 	onTraceLogClassicChange: (Boolean) -> Unit = {},
+	slideMode: Boolean = false,
+	onSlideModeChange: (Boolean) -> Unit = {},
 ) {
 	var showCommunityDialog by remember { mutableStateOf(false) }
 
@@ -519,6 +527,19 @@ private fun InfoContent(
 					Switch(
 						checked = traceLogClassic,
 						onCheckedChange = onTraceLogClassicChange,
+						colors = SwitchDefaults.colors(checkedTrackColor = Accent),
+					)
+				},
+			)
+			CardDivider()
+			SettingsRow(
+				title = stringResource(R.string.slide_mode),
+				subtitle = stringResource(R.string.slide_mode_desc),
+				onClick = { onSlideModeChange(!slideMode) },
+				trailing = {
+					Switch(
+						checked = slideMode,
+						onCheckedChange = onSlideModeChange,
 						colors = SwitchDefaults.colors(checkedTrackColor = Accent),
 					)
 				},

--- a/app/src/main/java/com/kimjisub/launchpad/manager/PreferenceManager.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/manager/PreferenceManager.kt
@@ -70,6 +70,15 @@ class PreferenceManager(
 			}
 		}
 
+	/** Slide Mode: dragging a finger onto a pad presses it and releases the one it left (#26). */
+	var slideMode: Boolean
+		get() = pref.getBoolean(KEY_SLIDE_MODE, false)
+		set(value) {
+			pref.edit {
+				putBoolean(KEY_SLIDE_MODE, value)
+			}
+		}
+
 	var downloadStoragePath: String?
 		get() = pref.getString(KEY_DOWNLOAD_STORAGE_PATH, null)
 		set(value) {
@@ -98,5 +107,6 @@ class PreferenceManager(
 		private const val KEY_DOWNLOAD_STORAGE_PATH = "download_storage_path"
 		private const val KEY_BACKUP_SAF_URI = "backup_saf_uri"
 		private const val KEY_TRACE_LOG_CLASSIC = "TraceLogClassic"
+		private const val KEY_SLIDE_MODE = "SlideMode"
 	}
 }

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -162,6 +162,8 @@
 	<string name="settings_play">연주</string>
 	<string name="trace_log_classic">예전 방식 순서 기록</string>
 	<string name="trace_log_classic_desc">선과 점 대신 각 패드에 누른 순서를 숫자로 표시합니다</string>
+	<string name="slide_mode">패드 슬라이드</string>
+	<string name="slide_mode_desc">손가락을 끌어 다른 패드에 들어가면 그 패드가 울리고 벗어난 패드는 멈춥니다</string>
 	<string name="settings_info">정보</string>
 	<string name="settings_storage">저장소</string>
 	<string name="settings_theme">테마</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,6 +173,8 @@
 	<string name="settings_play">Play</string>
 	<string name="trace_log_classic">Classic trace log</string>
 	<string name="trace_log_classic_desc">Show the tap order as numbers on each pad instead of lines and dots</string>
+	<string name="slide_mode">Slide across pads</string>
+	<string name="slide_mode_desc">Dragging a finger onto a pad plays it and stops the pad it left</string>
 	<string name="settings_info">Information</string>
 	<string name="settings_storage">Storage</string>
 	<string name="settings_theme">Theme</string>

--- a/design/src/main/java/com/kimjisub/design/view/SlideTouchOverlayView.kt
+++ b/design/src/main/java/com/kimjisub/design/view/SlideTouchOverlayView.kt
@@ -1,0 +1,99 @@
+package com.kimjisub.design.view
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.AttributeSet
+import android.util.SparseArray
+import android.view.MotionEvent
+import android.view.View
+
+/**
+ * Transparent layer over the pad grid for "Slide Mode": a finger that drags into a pad
+ * presses it and the pad it left is released, so a run can be played with one stroke.
+ * Multi-touch: every pointer is tracked on its own. When the layer is GONE the pads
+ * underneath get the touches as before.
+ */
+class SlideTouchOverlayView
+@JvmOverloads constructor(
+	context: Context,
+	attrs: AttributeSet? = null,
+	defStyleAttr: Int = 0,
+) : View(context, attrs, defStyleAttr) {
+
+	/** Called with (row, column, pressed). */
+	var listener: ((x: Int, y: Int, down: Boolean) -> Unit)? = null
+
+	private var rows = 0
+	private var cols = 0
+
+	// pointerId -> packed cell (row * cols + col) currently held by that pointer
+	private val held = SparseArray<Int>()
+
+	fun setGrid(rows: Int, cols: Int) {
+		this.rows = rows
+		this.cols = cols
+		releaseAll()
+	}
+
+	private fun releaseAll() {
+		for (i in 0 until held.size()) {
+			val cell = held.valueAt(i)
+			listener?.invoke(cell / cols, cell % cols, false)
+		}
+		held.clear()
+	}
+
+	@SuppressLint("ClickableViewAccessibility")
+	override fun onTouchEvent(event: MotionEvent): Boolean {
+		if (rows == 0 || cols == 0 || listener == null) return false
+		when (event.actionMasked) {
+			MotionEvent.ACTION_DOWN, MotionEvent.ACTION_POINTER_DOWN -> {
+				val i = event.actionIndex
+				press(event.getPointerId(i), event.getX(i), event.getY(i))
+			}
+			MotionEvent.ACTION_MOVE -> {
+				for (i in 0 until event.pointerCount) {
+					press(event.getPointerId(i), event.getX(i), event.getY(i))
+				}
+			}
+			MotionEvent.ACTION_UP, MotionEvent.ACTION_POINTER_UP -> {
+				release(event.getPointerId(event.actionIndex))
+			}
+			MotionEvent.ACTION_CANCEL -> releaseAll()
+		}
+		return true
+	}
+
+	private fun press(pointerId: Int, px: Float, py: Float) {
+		val cell = cellAt(px, py, width, height, rows, cols)
+		val previous = held.get(pointerId)
+		if (cell == previous) return
+		if (previous != null) listener?.invoke(previous / cols, previous % cols, false)
+		if (cell != null) {
+			held.put(pointerId, cell)
+			listener?.invoke(cell / cols, cell % cols, true)
+		} else {
+			held.remove(pointerId)
+		}
+	}
+
+	private fun release(pointerId: Int) {
+		val cell = held.get(pointerId) ?: return
+		held.remove(pointerId)
+		listener?.invoke(cell / cols, cell % cols, false)
+	}
+
+	companion object {
+		/**
+		 * Packed cell (row * cols + col) under a point, or null when the point is outside the
+		 * grid. Rows run top to bottom, columns left to right, matching the pad array [x][y].
+		 */
+		fun cellAt(px: Float, py: Float, width: Int, height: Int, rows: Int, cols: Int): Int? {
+			if (width <= 0 || height <= 0 || rows <= 0 || cols <= 0) return null
+			if (px < 0f || py < 0f || px >= width || py >= height) return null
+			val col = (px * cols / width).toInt().coerceIn(0, cols - 1)
+			val row = (py * rows / height).toInt().coerceIn(0, rows - 1)
+			return row * cols + col
+		}
+	}
+}

--- a/design/src/test/java/com/kimjisub/design/view/SlideTouchOverlayViewTest.kt
+++ b/design/src/test/java/com/kimjisub/design/view/SlideTouchOverlayViewTest.kt
@@ -1,0 +1,30 @@
+package com.kimjisub.design.view
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SlideTouchOverlayViewTest {
+
+	@Test
+	fun cellAt_mapsCornersOfAnEightByEightGrid() {
+		assertEquals(0, SlideTouchOverlayView.cellAt(0f, 0f, 800, 800, 8, 8))
+		assertEquals(7, SlideTouchOverlayView.cellAt(799f, 0f, 800, 800, 8, 8))
+		assertEquals(56, SlideTouchOverlayView.cellAt(0f, 799f, 800, 800, 8, 8))
+		assertEquals(63, SlideTouchOverlayView.cellAt(799f, 799f, 800, 800, 8, 8))
+	}
+
+	@Test
+	fun cellAt_usesRowTimesColsPlusCol_forNonSquareGrids() {
+		// 4 rows x 6 columns over 600x400: cell 100x100; point (250, 150) -> row 1, col 2
+		assertEquals(1 * 6 + 2, SlideTouchOverlayView.cellAt(250f, 150f, 600, 400, 4, 6))
+	}
+
+	@Test
+	fun cellAt_isNullOutsideTheGridOrWithoutAGrid() {
+		assertNull(SlideTouchOverlayView.cellAt(-1f, 10f, 800, 800, 8, 8))
+		assertNull(SlideTouchOverlayView.cellAt(800f, 10f, 800, 800, 8, 8))
+		assertNull(SlideTouchOverlayView.cellAt(10f, 10f, 800, 800, 0, 8))
+		assertNull(SlideTouchOverlayView.cellAt(10f, 10f, 0, 800, 8, 8))
+	}
+}


### PR DESCRIPTION
## What and why

Closes #26 (D-005 in the ops repo: opt-in, note-off on leaving a pad). iOS (`MultiTouchView.touchesMoved`) and the web player (`elementFromPoint` + pointer capture) already slide; Android only fired the first pad touched because each `PadView` owns its touch listener.

- `design/.../SlideTouchOverlayView`: transparent layer measured to the pad grid. Tracks each pointer id, maps the point to a cell with `cellAt()` (row = pad `x`, column = pad `y`), and on a cell change calls the listener with `(old, false)` then `(new, true)`. `ACTION_CANCEL` and `setGrid()` release everything held.
- `PlayActivity`: the layer is the seventh child of the pad `Layout`, placed at the pad origin above the trace overlay. `initLayout` sets the grid, wires `vm.padTouch`, and shows it only when `p.slideMode` is on; otherwise it is `GONE`, so touches reach the pads exactly as before.
- Settings > Play > "Slide across pads" (`PreferenceManager.slideMode`, key `SlideMode`, default off), strings en + ko.

## How you tested it

```
./gradlew :app:compileDebugKotlin :design:testDebugUnitTest --tests 'com.kimjisub.design.view.SlideTouchOverlayViewTest' -q
# EXIT=0; tests="3" failures="0" errors="0" (corner mapping, non-square grid, out-of-grid / no-grid)
```

Not run on a device; the `MotionEvent` path needs the framework. The cell math is the only logic and is unit-tested.

## UniPack compatibility
- [x] Existing UniPacks load and play exactly as before

## Related issues
Closes #26.
