### PR TITLE
fix(engine): close the blocker findings of the 2026-09-07 engine review

### DIFF
--- a/app/src/main/cpp/AudioEngine.cpp
+++ b/app/src/main/cpp/AudioEngine.cpp
@@ -34,9 +34,19 @@ bool AudioEngine::start() {
         return false;
     }
 
+    // The mixer below assumes interleaved stereo I16. Oboe may hand back something else
+    // (mono, float); writing stereo frames into that buffer would run past its end.
+    if (stream_->getChannelCount() != 2 || stream_->getFormat() != oboe::AudioFormat::I16) {
+        LOGE("Unexpected stream layout: channels=%d format=%d",
+             stream_->getChannelCount(), static_cast<int>(stream_->getFormat()));
+        stream_->close();
+        stream_.reset();
+        return false;
+    }
+
     outputSampleRate_ = stream_->getSampleRate();
     LOGI("Opened stream: sampleRate=%d, framesPerBurst=%d",
-         outputSampleRate_, stream_->getFramesPerBurst());
+         outputSampleRate_.load(), stream_->getFramesPerBurst());
 
     result = stream_->requestStart();
     if (result != oboe::Result::OK) {
@@ -60,6 +70,10 @@ void AudioEngine::stop() {
         stream->requestStop();
         stream->close();
     }
+    // The engine now lives for the process; voices left active here would resume mixing
+    // whatever occupies their soundId slots the next time start() runs.
+    std::lock_guard<std::mutex> lock(voiceMutex_);
+    for (auto& v : voices_) v.active = false;
 }
 
 int AudioEngine::loadSound(const int16_t* data, int numFrames, int channels, int sampleRate) {
@@ -86,13 +100,15 @@ void AudioEngine::unloadAll() {
 }
 
 int AudioEngine::play(int soundId, float volumeL, float volumeR, int loop) {
-    const SoundBuffer* buf = soundBank_.get(soundId);
-    if (!buf) return 0;
-
-    double rate = static_cast<double>(buf->sampleRate) / outputSampleRate_;
-    int key = nextStopKey_.fetch_add(1);
-
+    // voiceMutex_ before the bank lookup: unloadSound frees buffers under voiceMutex_, so the
+    // pointer stays valid for as long as we hold it (same order as onAudioReady).
     std::lock_guard<std::mutex> lock(voiceMutex_);
+    const SoundBuffer* buf = soundBank_.get(soundId);
+    if (!buf || buf->numFrames <= 0) return 0;
+
+    double rate = static_cast<double>(buf->sampleRate) / outputSampleRate_.load();
+    int key = nextStopKey_.fetch_add(1);
+    if (key == 0) key = nextStopKey_.fetch_add(1); // 0 means "no voice" to stopVoice
 
     // Find a free voice slot
     for (auto& v : voices_) {
@@ -109,8 +125,18 @@ int AudioEngine::play(int soundId, float volumeL, float volumeR, int loop) {
         }
     }
 
-    // All voices busy - steal the oldest one (first in array)
-    auto& v = voices_[0];
+    // All voices busy: steal the oldest one-shot voice (smallest stopKey), never an infinite
+    // loop (the backing track) while a one-shot is available.
+    ActiveVoice* victim = nullptr;
+    for (auto& cand : voices_) {
+        if (cand.loopCount == -1) continue;
+        if (!victim || cand.stopKey < victim->stopKey) victim = &cand;
+    }
+    if (!victim) {
+        victim = &voices_[0];
+        for (auto& cand : voices_) if (cand.stopKey < victim->stopKey) victim = &cand;
+    }
+    auto& v = *victim;
     v.soundId = soundId;
     v.position = 0.0;
     v.playbackRate = rate;
@@ -141,7 +167,9 @@ oboe::DataCallbackResult AudioEngine::onAudioReady(
     auto* output = static_cast<int16_t*>(audioData);
     std::memset(output, 0, numFrames * 2 * sizeof(int16_t)); // stereo
 
-    if (stopping_.load()) return oboe::DataCallbackResult::Stop;
+    // Silence is already in the buffer; let stop()'s requestStop/close tear the stream down
+    // rather than also asking Oboe to stop from inside the callback.
+    if (stopping_.load()) return oboe::DataCallbackResult::Continue;
 
     std::lock_guard<std::mutex> lock(voiceMutex_);
 
@@ -149,7 +177,7 @@ oboe::DataCallbackResult AudioEngine::onAudioReady(
         if (!v.active) continue;
 
         const SoundBuffer* buf = soundBank_.get(v.soundId);
-        if (!buf) {
+        if (!buf || buf->numFrames <= 0) {
             v.active = false;
             continue;
         }
@@ -157,25 +185,28 @@ oboe::DataCallbackResult AudioEngine::onAudioReady(
         for (int frame = 0; frame < numFrames; frame++) {
             int idx = static_cast<int>(v.position);
 
-            if (idx >= buf->numFrames) {
-                // Handle looping
+            // Wrap until idx is back inside the buffer: one subtraction is not enough when the
+            // playback rate exceeds the buffer length (short click resampled from 192 kHz).
+            while (idx >= buf->numFrames) {
                 if (v.loopCount == -1) {
                     v.position -= buf->numFrames;
-                    idx = static_cast<int>(v.position);
                 } else if (v.loopCount > 0) {
                     v.loopCount--;
                     v.position -= buf->numFrames;
-                    idx = static_cast<int>(v.position);
                 } else {
                     v.active = false;
                     break;
                 }
+                idx = static_cast<int>(v.position);
             }
+            if (!v.active) break;
+            if (idx < 0) idx = 0;
 
-            // Linear interpolation between samples
+            // Linear interpolation between samples; a one-shot's last frame must not blend
+            // toward frame 0 (audible click), only loops wrap.
             float frac = static_cast<float>(v.position - idx);
             int nextIdx = idx + 1;
-            if (nextIdx >= buf->numFrames) nextIdx = 0;
+            if (nextIdx >= buf->numFrames) nextIdx = (v.loopCount == 0) ? idx : 0;
 
             float sampleL, sampleR;
             if (buf->channels == 2) {

--- a/app/src/main/cpp/AudioEngine.h
+++ b/app/src/main/cpp/AudioEngine.h
@@ -56,5 +56,5 @@ private:
     SoundBank soundBank_;
     std::atomic<int> nextStopKey_{1};
     std::atomic<bool> stopping_{false};
-    int outputSampleRate_ = 48000;
+    std::atomic<int> outputSampleRate_{48000};
 };

--- a/app/src/main/cpp/SoundBank.cpp
+++ b/app/src/main/cpp/SoundBank.cpp
@@ -1,6 +1,7 @@
 #include "SoundBank.h"
 
 int SoundBank::load(const int16_t* data, int numFrames, int channels, int sampleRate) {
+    if (!data || numFrames <= 0 || channels <= 0 || sampleRate <= 0) return -1;
     auto buf = std::make_unique<SoundBuffer>();
     buf->numFrames = numFrames;
     buf->channels = channels;

--- a/app/src/main/cpp/jni_bridge.cpp
+++ b/app/src/main/cpp/jni_bridge.cpp
@@ -33,6 +33,9 @@ JNIEXPORT jint JNICALL
 Java_com_kimjisub_launchpad_audio_OboeAudioEngine_nativeLoadSound(
         JNIEnv* env, jobject, jshortArray pcmData, jint numFrames, jint channels, jint sampleRate) {
     if (!sEngine) return -1;
+    if (numFrames <= 0 || channels <= 0) return -1;
+    const jsize len = env->GetArrayLength(pcmData);
+    if (static_cast<jlong>(numFrames) * channels > len) return -1; // caller lied about the size
 
     jshort* data = env->GetShortArrayElements(pcmData, nullptr);
     if (!data) return -1;

--- a/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
@@ -99,6 +99,7 @@ import com.kimjisub.design.view.SlideTouchOverlayView
 import com.kimjisub.design.view.TraceLogOverlayView
 import com.kimjisub.launchpad.R
 import com.kimjisub.launchpad.R.string
+import com.kimjisub.launchpad.manager.ChannelManager
 import com.kimjisub.launchpad.manager.ChannelManager.Channel
 import com.kimjisub.launchpad.manager.IThemeResources
 import com.kimjisub.launchpad.manager.DefaultThemeResources
@@ -160,6 +161,10 @@ class PlayActivity : BaseActivity() {
 	private lateinit var chainViews: Array<ChainView?>
 	private var traceLogOverlayView: TraceLogOverlayView? = null
 	private var slideTouchOverlayView: SlideTouchOverlayView? = null
+	// Activity-scoped, unlike vm.uiLoaded: a recreated activity must rebuild its views even
+	// though the retained ViewModel says the UI was loaded, and two onSizeChanged calls before
+	// the posted runnable ran used to queue initLayout twice.
+	private var layoutRequested = false
 
 	// Classic trace log (numbers on pads): what is drawn right now, so one new tap only touches one pad.
 	private var classicTraceShown = false
@@ -443,7 +448,8 @@ class PlayActivity : BaseActivity() {
 				.let { mod ->
 					if (vm.startReady) {
 						mod.onSizeChanged { size ->
-							if (!vm.uiLoaded && size.width > 0 && size.height > 0) {
+							if (!layoutRequested && size.width > 0 && size.height > 0) {
+								layoutRequested = true
 								Handler(Looper.getMainLooper()).post {
 									initLayout(size.width, size.height, size.width - 2 * paddingPx, size.height - 2 * paddingPx)
 									vm.initRunner()
@@ -948,6 +954,7 @@ class PlayActivity : BaseActivity() {
 				listener = { x, y, down -> vm.padTouch(x, y, down) }
 				visibility = if (p.slideMode) View.VISIBLE else View.GONE
 			}
+			theme?.traceLog?.let { traceLogOverlayView?.setTraceColor(it) }
 			vm.traceLogInit()
 			vm.proLightMode(vm.scbProLightMode.isChecked())
 			vm.uiLoaded = true
@@ -1163,7 +1170,7 @@ class PlayActivity : BaseActivity() {
 		val range = VOLUME_LEVELS downTo TOP_BAR_COUNT - level
 		for (c in 0 until TOP_BAR_COUNT) {
 			val y = CHAIN_INDEX_OFFSET + c
-			if (c in range) vm.channelManager.add(-1, y, Channel.UI, -1, LED_BLUE) else vm.channelManager.remove(-1, y, Channel.UI)
+			if (c in range) vm.channelManager.add(-1, y, Channel.UI, ChannelManager.NO_COLOR, LED_BLUE) else vm.channelManager.remove(-1, y, Channel.UI)
 			uiCallback.setLedChain(y)
 		}
 	}
@@ -1177,6 +1184,8 @@ class PlayActivity : BaseActivity() {
 		contentResolver.registerContentObserver(Settings.System.CONTENT_URI, true, volumeObserver)
 		window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 		if (vm.uiLoaded) controller = midiController
+		// The setting may have changed in SettingsActivity while this activity sat in the back stack.
+		slideTouchOverlayView?.let { if (vm.uiLoaded) it.visibility = if (p.slideMode) View.VISIBLE else View.GONE }
 	}
 
 	override fun onPause() {

--- a/app/src/main/java/com/kimjisub/launchpad/audio/OboeAudioEngine.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/audio/OboeAudioEngine.kt
@@ -1,6 +1,7 @@
 package com.kimjisub.launchpad.audio
 
 import android.media.MediaCodec
+import com.kimjisub.launchpad.tool.Log
 import android.media.MediaExtractor
 import android.media.MediaFormat
 import java.io.File
@@ -89,8 +90,11 @@ object OboeAudioEngine {
 			extractor.selectTrack(trackIndex)
 			val format = extractor.getTrackFormat(trackIndex)
 			val mime = format.getString(MediaFormat.KEY_MIME) ?: return null
-			val sampleRate = format.getInteger(MediaFormat.KEY_SAMPLE_RATE)
-			val channels = format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+			var sampleRate = format.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+			var channels = format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+			// Ask for 16-bit PCM explicitly; FLAC/WAV tracks can otherwise decode to float, which
+			// asShortBuffer() would read as noise.
+			format.setInteger(MediaFormat.KEY_PCM_ENCODING, android.media.AudioFormat.ENCODING_PCM_16BIT)
 
 			// Pre-allocate based on duration estimate
 			val durationUs = format.getLongOrDefault(MediaFormat.KEY_DURATION, 0L)
@@ -101,6 +105,7 @@ object OboeAudioEngine {
 			}
 
 			val codec = MediaCodec.createDecoderByType(mime)
+			try {
 			codec.configure(format, null, null, 0)
 			codec.start()
 
@@ -111,6 +116,10 @@ object OboeAudioEngine {
 			var inputDone = false
 			var outputDone = false
 			val timeoutUs = 5_000L
+			// Some OEM decoders answer TRY_AGAIN_LATER forever on a truncated file; without a
+			// budget the loading dialog never closes.
+			var idleRounds = 0
+			val maxIdleRounds = 2_000 // 2000 x 5 ms = 10 s of nothing after EOS
 
 			while (!outputDone) {
 				if (!inputDone) {
@@ -131,7 +140,19 @@ object OboeAudioEngine {
 				}
 
 				val outputIndex = codec.dequeueOutputBuffer(bufferInfo, timeoutUs)
+				if (outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+					// HE-AAC (SBR) decodes at twice the container rate; keep the real output layout.
+					val out = codec.outputFormat
+					if (out.containsKey(MediaFormat.KEY_SAMPLE_RATE)) sampleRate = out.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+					if (out.containsKey(MediaFormat.KEY_CHANNEL_COUNT)) channels = out.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+				} else if (outputIndex == MediaCodec.INFO_TRY_AGAIN_LATER) {
+					if (inputDone && ++idleRounds > maxIdleRounds) {
+						Log.err("decode stalled after EOS: ${file.name}")
+						return null
+					}
+				}
 				if (outputIndex >= 0) {
+					idleRounds = 0
 					if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) {
 						outputDone = true
 					}
@@ -139,6 +160,8 @@ object OboeAudioEngine {
 					val outputBuffer = codec.getOutputBuffer(outputIndex)
 					if (outputBuffer != null && bufferInfo.size > 0) {
 						outputBuffer.order(ByteOrder.nativeOrder())
+						outputBuffer.position(bufferInfo.offset)
+						outputBuffer.limit(bufferInfo.offset + bufferInfo.size)
 						val shortBuf = outputBuffer.asShortBuffer()
 						val numShorts = bufferInfo.size / 2
 
@@ -155,15 +178,21 @@ object OboeAudioEngine {
 			}
 
 			codec.stop()
-			codec.release()
 
 			if (totalSamples == 0) return null
 
 			// Trim to exact size
 			val finalPcm = if (pcm.size == totalSamples) pcm else pcm.copyOf(totalSamples)
 			val numFrames = totalSamples / channels
+			if (numFrames <= 0) return null
 			return DecodedAudio(finalPcm, numFrames, channels, sampleRate)
+			} finally {
+				// Released on every path; a codec leaked per failed file exhausted the device's
+				// codec instances and made every later sound fail to load.
+				codec.release()
+			}
 		} catch (e: Exception) {
+			Log.err("decode failed: ${file.name}", e)
 			return null
 		} finally {
 			extractor.release()

--- a/app/src/main/java/com/kimjisub/launchpad/manager/ChannelManager.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/manager/ChannelManager.kt
@@ -3,6 +3,9 @@ package com.kimjisub.launchpad.manager
 class ChannelManager(x: Int, y: Int) {
 	companion object {
 		private const val CIRCULAR_BUTTON_COUNT = 36
+		/** "No explicit colour, derive it from the LED code". Must not collide with a real ARGB
+		 *  value: -1 is 0xFFFFFFFF, an opaque white LED, which used to render as ARGB[code] (pink). */
+		const val NO_COLOR = Int.MIN_VALUE
 	}
 
 	private var btn: Array<Array<Array<Item?>>>
@@ -60,7 +63,7 @@ class ChannelManager(x: Int, y: Int) {
 	}
 
 	fun add(x: Int, y: Int, channel: Channel, color: Int, code: Int) {
-		val resolvedColor = if (color == -1) LaunchpadColor.ARGB[code].toInt() else color
+		val resolvedColor = if (color == NO_COLOR) LaunchpadColor.ARGB[code].toInt() else color
 		if (x != -1)
 			btn[x][y][channel.priority] = Item(channel, resolvedColor, code)
 		else

--- a/app/src/main/java/com/kimjisub/launchpad/unipack/runner/AutoPlayRunner.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/unipack/runner/AutoPlayRunner.kt
@@ -108,7 +108,12 @@ class AutoPlayRunner(
 				progress = 0
 				listener.onStart()
 
-				val autoPlay = unipack.autoPlayTable ?: return@launch
+				val autoPlay = unipack.autoPlayTable
+				if (autoPlay == null) {
+					// onStart already put the UI into "playing"; without onEnd it stays there.
+					listener.onEnd()
+					return@launch
+				}
 
 				if (practiceGuide) {
 					guideTimeline = buildGuideTimeline(autoPlay)
@@ -322,15 +327,8 @@ class AutoPlayRunner(
 	}
 
 	fun progressOffset(offset: Int) {
-		val range = 0 until Int.MAX_VALUE
-		val targetProgress = progress + offset
-
-		progress =
-			when {
-				range.first > targetProgress -> range.first
-				range.last < targetProgress -> range.last
-				else -> targetProgress
-			}
+		val size = unipack.autoPlayTable?.elements?.size ?: 0
+		progress = (progress + offset).coerceIn(0, size)
 		if (stepMode) {
 			resetStepState()
 			listener.onRemoveGuide()
@@ -347,6 +345,10 @@ class AutoPlayRunner(
 			stepStartProgress = 0
 			stepChainValue = -1
 		}
+		// A chain wait left over from step mode would otherwise resume with waitStartTime == 0 and
+		// push startTime far into the future, freezing autoplay (2026-09-07 review).
+		waitingForChain = -1
+		waitStartTime = SystemClock.elapsedRealtime()
 	}
 
 	fun stepPadPressed(x: Int, y: Int) {

--- a/app/src/main/java/com/kimjisub/launchpad/unipack/runner/ChainObserver.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/unipack/runner/ChainObserver.kt
@@ -1,7 +1,16 @@
 package com.kimjisub.launchpad.unipack.runner
 
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Current chain plus its observers. `value` is written from several threads (main, the LED
+ * runner via its listener, the wormhole delay in SoundRunner), so the field is volatile and
+ * the observer list copy-on-write; observers themselves run on the thread that sets `value`.
+ */
 class ChainObserver {
 	var range: IntRange = Int.MIN_VALUE..Int.MAX_VALUE
+
+	@Volatile
 	var value: Int = 0
 		set(value) {
 			val realValue =
@@ -16,7 +25,7 @@ class ChainObserver {
 			refresh(field, prev)
 		}
 
-	private val observerList: MutableList<(curr: Int, prev: Int) -> Unit> = mutableListOf()
+	private val observerList = CopyOnWriteArrayList<(curr: Int, prev: Int) -> Unit>()
 
 	fun refresh(curr: Int = value, prev: Int = value) {
 		for (observer in observerList)

--- a/app/src/main/java/com/kimjisub/launchpad/unipack/runner/LedRunner.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/unipack/runner/LedRunner.kt
@@ -39,6 +39,8 @@ class LedRunner(
 		fun onPadLedTurnOff(x: Int, y: Int)
 		fun onChainLedTurnOn(c: Int, color: Int, velocity: Int)
 		fun onChainLedTurnOff(c: Int)
+		/** A keyLED `c` event. Called on the runner thread; the listener decides where to apply it. */
+		fun onChainChange(c: Int)
 	}
 
 	private fun loop() {
@@ -48,12 +50,21 @@ class LedRunner(
 				if (state.isPlaying && !state.isShutdown) {
 					// Init if First
 					if (state.delay == 0L) state.delay = currTime
+					var processed = 0
 					while (true) {
 						// Counting Up Loop Progress
 						val ledEvents = state.ledAnimation?.ledEvents ?: break
 						// An empty keyLED file gives an animation with no events; with loop 0 the old code
 						// spun into ledEvents[0] on an empty list (Crashlytics a1376611).
 						if (ledEvents.isEmpty()) {
+							state.isPlaying = false
+							break
+						}
+						// An animation with no delay lines never pushes state.delay past currTime, so
+						// this loop would run forever while holding the monitor and the next padTouch
+						// would block into an ANR. One tick may consume at most one full pass per loop.
+						val loopCount = state.ledAnimation.loop.coerceAtLeast(1)
+						if (++processed > ledEvents.size * loopCount + 1) {
 							state.isPlaying = false
 							break
 						}
@@ -106,7 +117,9 @@ class LedRunner(
 									}
 
 									is LedAnimation.LedEvent.Chain -> {
-										chain.value = event.chain
+										// Not chain.value here: ChainObserver runs its observers synchronously and
+										// they touch UI state, so the listener applies the change on main.
+										listener.onChainChange(event.chain)
 									}
 								}
 							} catch (ex: IndexOutOfBoundsException) {
@@ -138,8 +151,7 @@ class LedRunner(
 			for (item in ledAnimationStatesAdd)
 				ledAnimationStates.add(item)
 			ledAnimationStatesAdd.clear()
-			ledAnimationStates =
-				ledAnimationStates.filter { !it.remove }.toMutableList()
+			ledAnimationStates.removeAll { it.remove }
 		}
 	}
 
@@ -164,6 +176,7 @@ class LedRunner(
 		Log.thread("[Led] 3. Request Stop")
 		job?.cancel()
 		job = null
+		synchronized(this) { ledAnimationStatesAdd.clear() }
 	}
 
 	// Functions
@@ -216,12 +229,12 @@ class LedRunner(
 	}
 
 	fun eventOffAll(x: Int, y: Int) {
-		if (active) {
-			synchronized(this) {
-				for (state in ledAnimationStates) {
-					if (state.buttonX == x && state.buttonY == y && state.ledAnimation?.loop == 0) {
-						state.isShutdown = true
-					}
+		// No `active` guard: ledInit() calls this right after stop() to shut the looping
+		// animations down; with the guard they stayed isPlaying and replayed in a burst on relaunch.
+		synchronized(this) {
+			for (state in ledAnimationStates) {
+				if (state.buttonX == x && state.buttonY == y && state.ledAnimation?.loop == 0) {
+					state.isShutdown = true
 				}
 			}
 		}

--- a/app/src/main/java/com/kimjisub/launchpad/unipack/runner/SoundRunner.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/unipack/runner/SoundRunner.kt
@@ -23,6 +23,7 @@ class SoundRunner(
 ) {
 
 	private var stopKey: Array<Array<Array<Int>>>
+	@Volatile
 	private var engineStarted = false
 
 	interface LoadingListener {
@@ -105,7 +106,7 @@ class SoundRunner(
 
 				// Phase 3: Load decoded PCM into native engine (sequential, fast)
 				for ((filePath, sounds) in uniqueFiles) {
-					val decoded = decodedCache[filePath] ?: continue
+					val decoded = decodedCache.remove(filePath) ?: continue  // drop the JVM copy as we go
 					val soundId = OboeAudioEngine.loadDecoded(decoded)
 					if (soundId < 0) {
 						Log.err("Failed to load into engine: $filePath")
@@ -117,7 +118,9 @@ class SoundRunner(
 				}
 
 				loadingListener.onEnd()
-			} catch (e: RuntimeException) {
+			} catch (e: Throwable) {
+				// OutOfMemoryError and UnsatisfiedLinkError are Errors, not RuntimeExceptions, and
+				// used to take the process down instead of reaching onException.
 				Log.err("[08] doInBackground", e)
 				loadingListener.onException(e)
 			}
@@ -170,6 +173,7 @@ class SoundRunner(
 					}
 		}
 		if (engineStarted) {
+			OboeAudioEngine.unloadAll() // ids assigned after destroy() started are freed too
 			OboeAudioEngine.stop()
 		}
 	}

--- a/app/src/main/java/com/kimjisub/launchpad/unipack/struct/Sound.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/unipack/struct/Sound.kt
@@ -7,7 +7,7 @@ data class Sound(
 	val loop: Int,
 	val wormhole: Int = NO_WORMHOLE,
 	var num: Int = 0,
-	var id: Int = -1,
+	@Volatile var id: Int = -1,
 ) {
 	companion object {
 		const val NO_WORMHOLE = -1

--- a/app/src/main/java/com/kimjisub/launchpad/viewmodel/PlayActivityViewModel.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/viewmodel/PlayActivityViewModel.kt
@@ -303,7 +303,10 @@ class PlayActivityViewModel(
 						uiCallback?.setLedChain(c)
 					}
 
-					})
+					override fun onChainChange(c: Int) {
+						viewModelScope.launch { chain.value = c }
+					}
+				})
 		}
 
 		initAutoPlayRunner()
@@ -403,7 +406,7 @@ class PlayActivityViewModel(
 				if (scbTraceLog.isChecked())
 					traceLogLog(x, y)
 				if (scbFeedbackLight.isChecked()) {
-					channelManager.add(x, y, Channel.PRESSED, -1, LED_RED)
+					channelManager.add(x, y, Channel.PRESSED, ChannelManager.NO_COLOR, LED_RED)
 					uiCallback?.setLedPad(x, y)
 				}
 				ledRunner?.eventOn(x, y)
@@ -431,7 +434,7 @@ class PlayActivityViewModel(
 			for (c in 0 until MAX_CHAIN_BUTTONS) {
 				val y = CHAIN_INDEX_OFFSET + c
 				if (c == chain.value)
-					channelManager.add(-1, y, Channel.CHAIN, -1, LED_RED)
+					channelManager.add(-1, y, Channel.CHAIN, ChannelManager.NO_COLOR, LED_RED)
 				else
 					channelManager.remove(-1, y, Channel.CHAIN)
 				uiCallback?.setLedChain(y)
@@ -483,7 +486,7 @@ class PlayActivityViewModel(
 			topBar[7] = LED_BLUE
 			for (i in 0 until TOP_BAR_COUNT) {
 				if (topBar[i] != 0)
-					channelManager.add(-1, i, Channel.UI_UNIPAD, -1, topBar[i])
+					channelManager.add(-1, i, Channel.UI_UNIPAD, ChannelManager.NO_COLOR, topBar[i])
 				else channelManager.remove(-1, i, Channel.UI_UNIPAD)
 				uiCallback?.setLedChain(i)
 			}
@@ -500,7 +503,7 @@ class PlayActivityViewModel(
 			topBar[7] = LED_RED_BRIGHT
 			for (i in 0 until TOP_BAR_COUNT) {
 				if (topBar[i] != 0) channelManager.add(
-					-1, i, Channel.UI, -1, topBar[i]
+					-1, i, Channel.UI, ChannelManager.NO_COLOR, topBar[i]
 				) else channelManager.remove(-1, i, Channel.UI)
 				uiCallback?.setLedChain(i)
 			}
@@ -701,7 +704,7 @@ class PlayActivityViewModel(
 
 	private fun autoPlayGuidePad(x: Int, y: Int, onOff: Boolean, targetWallTimeMs: Long = 0) {
 		if (onOff) {
-			channelManager.add(x, y, Channel.GUIDE, -1, LED_ORANGE)
+			channelManager.add(x, y, Channel.GUIDE, ChannelManager.NO_COLOR, LED_ORANGE)
 			uiCallback?.setLedPad(x, y)
 			uiCallback?.startGuideAnimation(x, y, targetWallTimeMs)
 		} else {
@@ -749,6 +752,9 @@ class PlayActivityViewModel(
 	fun initAutoPlayRunner() {
 		if (!unipack.autoPlayExist) return
 		autoPlayRunner?.stop()
+		// onEnd of a stopped runner arrives asynchronously; by then autoPlayRunner may already be
+		// its replacement, whose flags the old one must not reset.
+		var created: AutoPlayRunner? = null
 		autoPlayRunner = AutoPlayRunner(
 			unipack = unipack,
 			chain = chain,
@@ -787,7 +793,7 @@ class PlayActivityViewModel(
 
 				override fun onGuideChainOn(c: Int) {
 					viewModelScope.launch {
-						channelManager.add(-1, CHAIN_INDEX_OFFSET + c, Channel.GUIDE, -1, LED_ORANGE)
+						channelManager.add(-1, CHAIN_INDEX_OFFSET + c, Channel.GUIDE, ChannelManager.NO_COLOR, LED_ORANGE)
 						uiCallback?.setLedChain(CHAIN_INDEX_OFFSET + c)
 					}
 				}
@@ -806,6 +812,7 @@ class PlayActivityViewModel(
 
 				override fun onEnd() {
 					viewModelScope.launch {
+						if (created != null && created !== autoPlayRunner) return@launch
 						isAutoPlayPlaying = false
 						autoPlayRunner?.practiceGuide = false
 						autoPlayRunner?.stepMode = false
@@ -822,6 +829,7 @@ class PlayActivityViewModel(
 					}
 				}
 			})
+		created = autoPlayRunner
 	}
 
 	fun autoMapping() {

--- a/app/src/test/java/com/kimjisub/launchpad/manager/ChannelManagerTest.kt
+++ b/app/src/test/java/com/kimjisub/launchpad/manager/ChannelManagerTest.kt
@@ -156,15 +156,24 @@ class ChannelManagerTest {
 		assertEquals(ChannelManager.Channel.CHAIN, item.channel)
 	}
 
-	// === Color -1 conversion from LaunchpadColor.ARGB ===
+	// === NO_COLOR sentinel resolves through LaunchpadColor.ARGB ===
 
 	@Test
-	fun add_withNegativeOneColor_usesLaunchpadColorARGB() {
+	fun add_withNoColor_usesLaunchpadColorARGB() {
 		val code = 5 // LaunchpadColor.ARGB[5] = 0xFFef5350
-		manager.add(0, 0, ChannelManager.Channel.LED, -1, code)
+		manager.add(0, 0, ChannelManager.Channel.LED, ChannelManager.NO_COLOR, code)
 		val item = requireNotNull(manager.get(0, 0)) { "Expected item with ARGB color" }
 		assertEquals(LaunchpadColor.ARGB[code].toInt(), item.color)
 		assertEquals(code, item.code)
+	}
+
+	@Test
+	fun add_withOpaqueWhite_keepsWhite() {
+		// 0xFFFFFFFF is -1 as an Int; it used to be mistaken for the sentinel and rendered as ARGB[code].
+		val white = 0xFFFFFFFF.toInt()
+		manager.add(0, 0, ChannelManager.Channel.LED, white, 5)
+		val item = requireNotNull(manager.get(0, 0))
+		assertEquals(white, item.color)
 	}
 
 	// === Multi-channel conflict scenarios ===


### PR DESCRIPTION
## What

Fixes the blocker-level findings from the whole-repo review of the play engine (runners, native audio, decoder, PlayActivity wiring). Full review notes live in the private workspace repo under `design/2026-09-07/reviews/android-unipack-runners.md`.

### Runners
- `LedRunner`: a LED file whose events all have delay 0 (or loop 0) used to spin the runner thread forever. The loop now stops once it has processed more events than the file can deliver. Chain changes go through the listener (main thread) instead of writing `ChainObserver` from the worker; finished animations are removed in one pass; `stop()` also drops pending additions.
- `ChainObserver`: `@Volatile` value, `CopyOnWriteArrayList` observers.
- `ChannelManager`: the "use the palette colour" sentinel is `NO_COLOR` (`Int.MIN_VALUE`) instead of `-1`. A LED coloured opaque white (`0xFFFFFFFF == -1`) was rendered as the palette entry for its code (pink for code 5). Test added.
- `AutoPlayRunner`: `onEnd()` when there is no table, clamped `progressOffset`, chain-wait state reset with the rest.
- `SoundRunner`: decoded cache entry dropped after upload, `Throwable` caught so a native OOM reaches `onException`, `destroy()` unloads before stopping.
- `PlayActivityViewModel`: AutoPlay `onEnd` from a replaced runner is ignored.

### Native audio
- `AudioEngine`: verifies the stream is stereo I16 before mixing; renormalises the read index with a loop (a playback rate above the buffer length read past the end); rejects empty buffers; `stop()` deactivates voices; callback returns `Continue` while stopping; voice stealing takes the oldest one-shot rather than the infinite loop; stopKey 0 skipped; `outputSampleRate_` atomic.
- `SoundBank` / `jni_bridge`: reject non-positive sizes and arrays shorter than `numFrames * channels`.
- `OboeAudioEngine.decode`: codec released on every path (a leaked codec per failed file exhausted the device's instances), `INFO_OUTPUT_FORMAT_CHANGED` handled (HE-AAC doubles the rate), 16-bit PCM requested, buffer offset/limit honoured, 10 s stall budget after EOS.

### PlayActivity
- Layout init requested once per activity instance (`layoutRequested`), so a recreated activity rebuilds views and two early `onSizeChanged` calls no longer init twice.
- Trace overlay gets the theme colour; Slide Mode visibility re-applied in `onResume`.

## Verification

| Check | Result |
|---|---|
| `:app:compileDebugKotlin` | ok |
| `:app:externalNativeBuildDebug` | ok |
| `:app:testDebugUnitTest` + `:design:testDebugUnitTest` | 265 / 265 |
| `:app:lintDebug` | 0 errors |

UniPack format behaviour is unchanged: no parsing became stricter; only runtime guards were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)