### PR TITLE
fix(midi): close the blocker and major findings of the 2026-09-07 MIDI review

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 	xmlns:tools="http://schemas.android.com/tools">
 
 	<uses-feature
-		android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+		android:name="android.hardware.usb.host"
 		android:required="false" />
 	<uses-feature
 		android:glEsVersion="0x00020000"

--- a/app/src/main/java/com/kimjisub/launchpad/activity/UsbMidiHandlerActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/UsbMidiHandlerActivity.kt
@@ -1,5 +1,6 @@
 package com.kimjisub.launchpad.activity
 
+import android.content.Intent
 import android.hardware.usb.UsbManager
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
@@ -13,9 +14,22 @@ class UsbMidiHandlerActivity : AppCompatActivity() {
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 
-		val usbManager = getSystemService(USB_SERVICE) as UsbManager
-		MidiConnection.initConnection(intent, usbManager, this)
-
+		handle(intent)
 		finish()
+	}
+
+	// singleInstance + noHistory: a second attach delivered to a live instance arrives here
+	// instead of onCreate and used to be dropped.
+	override fun onNewIntent(intent: Intent) {
+		super.onNewIntent(intent)
+		setIntent(intent)
+		handle(intent)
+		finish()
+	}
+
+	private fun handle(intent: Intent) {
+		// Devices without USB host support have no UsbManager; the manifest never required the feature.
+		val usbManager = getSystemService(USB_SERVICE) as? UsbManager ?: return
+		MidiConnection.initConnection(intent, usbManager, this)
 	}
 }

--- a/app/src/main/java/com/kimjisub/launchpad/midi/MidiConnection.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/MidiConnection.kt
@@ -30,14 +30,19 @@ import com.kimjisub.launchpad.midi.driver.Matrix
 import com.kimjisub.launchpad.midi.driver.MidiFighter
 import com.kimjisub.launchpad.midi.driver.Noting
 import com.kimjisub.launchpad.tool.Log
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
 
 
 object MidiConnection {
@@ -109,9 +114,13 @@ object MidiConnection {
 						offset += USB_MIDI_PACKET_SIZE
 					}
 
-					usbDeviceConnection?.bulkTransfer(
-						usbEndpointOut, batchBuffer, offset, USB_BULK_TIMEOUT_MS
-					)
+					// Read both fields once: teardown() nulls them in sequence from another thread.
+					val conn = usbDeviceConnection
+					val ep = usbEndpointOut
+					if (conn != null && ep != null) {
+						val written = conn.bulkTransfer(ep, batchBuffer, offset, USB_BULK_TIMEOUT_MS)
+						if (written < 0) Log.midiDetail("USB TX failed ($written), ${offset / USB_MIDI_PACKET_SIZE} packets dropped")
+					}
 				} catch (_: RuntimeException) {
 					// Device may be disconnected
 				}
@@ -128,7 +137,11 @@ object MidiConnection {
 	// Android MIDI API for SysEx delivery (used before USB interface claim)
 	private var midiManager: MidiManager? = null
 	private var midiDevice: MidiDevice? = null
-	private val midiInputPorts = mutableMapOf<Int, MidiInputPort>()
+	// Written from the init coroutine (IO) and closeMidiApi (main), read from sendRawBuffer (IO).
+	private val midiInputPorts = ConcurrentHashMap<Int, MidiInputPort>()
+	private var pendingInitJob: Job? = null
+	@Volatile
+	private var initSysExSent = false
 
 	// Deferred USB claim - stored for later use after MIDI API SysEx
 	private var pendingUsbClaim: (() -> Unit)? = null
@@ -154,10 +167,10 @@ object MidiConnection {
 				field.initialize()
 				if (isRun)
 					field.onConnected()
-			} catch (e: IllegalAccessException) {
+			} catch (e: RuntimeException) {
+				// initialize() sends the driver's init SysEx; a send failure must not take the
+				// caller (MidiSelectActivity's click, UsbMidiHandlerActivity.onCreate) down with it.
 				Log.err("Driver set failed", e)
-			} catch (e: InstantiationException) {
-				Log.err("Driver instantiation failed", e)
 			}
 
 			listener?.onChangeDriver(value)
@@ -193,9 +206,16 @@ object MidiConnection {
 		if ("android.hardware.usb.action.USB_DEVICE_ATTACHED" == intent.action)
 			initDevice(usbDevice)
 		else {
-			val deviceIterator = requireNotNull(usbManager).deviceList.values.iterator()
-			if (deviceIterator.hasNext())
-				initDevice(deviceIterator.next())
+			// Without an attach intent nothing was granted to us. Only a device we already hold
+			// permission for, and that looks like a MIDI device, is worth opening: the first entry
+			// of deviceList used to be a hub or a mouse and ended up published as "Master Keyboard".
+			val candidate = try {
+				usbManager.deviceList.values.firstOrNull { usbManager.hasPermission(it) && looksLikeMidiDevice(it) }
+			} catch (e: RuntimeException) {
+				Log.err("USB enumeration failed", e)
+				null
+			}
+			if (candidate != null) initDevice(candidate)
 		}
 
 		onCycleListener = object : DriverRef.OnCycleListener {
@@ -258,6 +278,10 @@ object MidiConnection {
 			Log.midiDetail("USB 에러 : device == null")
 			return
 		}
+
+		// A previous device (replug, or a second attach) must release its fd and stop its
+		// receive loop before its fields are overwritten.
+		teardown(notify = true)
 
 		try {
 			Log.midiDetail("DeviceName : ${device.deviceName}")
@@ -335,6 +359,7 @@ object MidiConnection {
 		}
 		val usbIf = usbInterface ?: run {
 			Log.midiDetail("USB 에러 : usbInterface == null")
+			connectedDevice = null
 			return
 		}
 		for (i in 0 until usbIf.endpointCount) {
@@ -348,13 +373,30 @@ object MidiConnection {
 				UsbConstants.USB_DIR_OUT -> usbEndpointOut = ep
 			}
 		}
-		val manager = usbManager ?: run {
-			Log.midiDetail("USB 에러 : usbManager == null")
+		val endpointIn = usbEndpointIn ?: run {
+			Log.midiDetail("USB 에러 : usbEndpointIn == null")
+			connectedDevice = null
 			return
 		}
-		val connection = manager.openDevice(device)
+		val manager = usbManager ?: run {
+			Log.midiDetail("USB 에러 : usbManager == null")
+			connectedDevice = null
+			return
+		}
+		// openDevice throws SecurityException for a device we were not granted (only the device
+		// that fired the attach intent is auto-granted).
+		val connection = try {
+			if (manager.hasPermission(device)) manager.openDevice(device) else {
+				Log.midiDetail("USB 에러 : no permission for ${device.deviceName}")
+				null
+			}
+		} catch (e: SecurityException) {
+			Log.err("USB openDevice failed", e)
+			null
+		}
 		if (connection == null) {
 			Log.midiDetail("USB 에러 : usbDeviceConnection == null")
+			connectedDevice = null
 			return
 		}
 		usbDeviceConnection = connection
@@ -362,10 +404,15 @@ object MidiConnection {
 		// Defer USB interface claim - MIDI API needs the interface first for SysEx
 		pendingUsbClaim = {
 			Log.midiDetail("USB: Claiming interface for MIDI communication")
-			if (connection.claimInterface(usbIf, true)) {
-				startReceiveLoop()
+			if (usbDeviceConnection !== connection) {
+				Log.midiDetail("USB: device changed before the claim, skipping")
+			} else if (connection.claimInterface(usbIf, true)) {
+				startReceiveLoop(connection, endpointIn)
 			} else {
+				// Announcing "connected" while owning no interface left the UI streaming LEDs
+				// to a device that never answered; report the disconnect instead.
 				Log.midiDetail("USB 에러 : claimInterface failed")
+				teardown(notify = true)
 			}
 		}
 
@@ -387,17 +434,24 @@ object MidiConnection {
 			return
 		}
 
-		@Suppress("DEPRECATION")
-		val deviceInfos = manager.devices
-		Log.midiDetail("MIDI API: ${deviceInfos.size} device(s) found")
-
-		val targetInfo = deviceInfos.firstOrNull { info ->
+		// Every call below is a binder round-trip into the MIDI service that produced the
+		// Android 16 NullPointerExceptions (#41/#49); openDevice was guarded, enumeration was not.
+		val targetInfo = try {
+			@Suppress("DEPRECATION")
+			val deviceInfos = manager.devices
+			Log.midiDetail("MIDI API: ${deviceInfos.size} device(s) found")
+			deviceInfos.firstOrNull { info ->
 			val props = info.properties
 			Log.midiDetail("MIDI API device: name=${props.getString(MidiDeviceInfo.PROPERTY_NAME)}, " +
 				"manufacturer=${props.getString(MidiDeviceInfo.PROPERTY_MANUFACTURER)}, " +
 				"product=${props.getString(MidiDeviceInfo.PROPERTY_PRODUCT)}, " +
 				"inputPorts=${info.inputPortCount}, outputPorts=${info.outputPortCount}")
-			info.inputPortCount > 0
+				info.inputPortCount > 0
+			}
+		} catch (e: RuntimeException) {
+			Log.err("MIDI API: enumeration failed, claiming USB interface directly", e)
+			claimUsbAndStart()
+			return
 		}
 
 		if (targetInfo == null) {
@@ -406,13 +460,12 @@ object MidiConnection {
 			return
 		}
 
-		Log.midiDetail("MIDI API: Opening device (inputPorts=${targetInfo.inputPortCount}, outputPorts=${targetInfo.outputPortCount})")
-		for (port in targetInfo.ports) {
-			val dir = if (port.type == MidiDeviceInfo.PortInfo.TYPE_INPUT) "INPUT" else "OUTPUT"
-			Log.midiDetail("  MIDI API Port[${port.portNumber}]: $dir name=${port.name}")
-		}
-
 		try {
+			Log.midiDetail("MIDI API: Opening device (inputPorts=${targetInfo.inputPortCount}, outputPorts=${targetInfo.outputPortCount})")
+			for (port in targetInfo.ports) {
+				val dir = if (port.type == MidiDeviceInfo.PortInfo.TYPE_INPUT) "INPUT" else "OUTPUT"
+				Log.midiDetail("  MIDI API Port[${port.portNumber}]: $dir name=${port.name}")
+			}
 			manager.openDevice(targetInfo, { device ->
 				// Runs later on the main Handler, outside the try below: a framework exception here
 				// (Crashlytics 9b99a871: SecurityException from openInputPort on Android 16) must fall
@@ -432,39 +485,57 @@ object MidiConnection {
 	}
 
 	private fun onMidiApiDeviceOpened(device: MidiDevice?, targetInfo: MidiDeviceInfo) {
-		if (device != null) {
-			midiDevice = device
-			Log.midiDetail("MIDI API: Device opened successfully")
-
-			// Open all input ports and send SysEx
-			for (portInfo in targetInfo.ports) {
-				if (portInfo.type == MidiDeviceInfo.PortInfo.TYPE_INPUT) {
-					val port = device.openInputPort(portInfo.portNumber)
-					if (port != null) {
-						midiInputPorts[portInfo.portNumber] = port
-						Log.midiDetail("MIDI API: Opened input port ${portInfo.portNumber} (${portInfo.name})")
-					}
-				}
-			}
-
-			// Send SysEx to ALL input ports (port names are empty, we don't know which is DAW)
-			val initData = driver.getInitSysEx()
-			if (initData != null && midiInputPorts.isNotEmpty()) {
-				val (messages, _) = initData
-				for ((portNum, _) in midiInputPorts) {
-					Log.midiDetail("MIDI API: Sending init SysEx (${messages.size} messages) to port $portNum")
-					sendViaMidiApi(messages, portNum)
-				}
-			}
-
-			// Delay to ensure SysEx is flushed before closing ports
-			Handler(Looper.getMainLooper()).postDelayed({
-				closeMidiApi()
-				claimUsbAndStart()
-			}, 500)
-		} else {
+		if (device == null) {
 			Log.midiDetail("MIDI API: Failed to open device, claiming USB interface directly")
 			claimUsbAndStart()
+			return
+		}
+		midiDevice = device
+		Log.midiDetail("MIDI API: Device opened successfully")
+
+		// Port opening and the SysEx sends (blocking port.send + 50 ms sleeps per message, per
+		// port) used to run on the main thread inside the attach path; a Pro MK3 with several
+		// ports froze the UI. The job is owned so teardown() can cancel it on an early unplug.
+		val connectionAtOpen = usbDeviceConnection
+		pendingInitJob?.cancel()
+		pendingInitJob = ioScope.launch {
+			try {
+				try {
+					for (portInfo in targetInfo.ports) {
+						if (portInfo.type == MidiDeviceInfo.PortInfo.TYPE_INPUT) {
+							val port = device.openInputPort(portInfo.portNumber)
+							if (port != null) {
+								midiInputPorts[portInfo.portNumber] = port
+								Log.midiDetail("MIDI API: Opened input port ${portInfo.portNumber} (${portInfo.name})")
+							}
+						}
+					}
+
+					// Send SysEx to ALL input ports (port names are empty, we don't know which is DAW)
+					val initData = driver.getInitSysEx()
+					if (initData != null && midiInputPorts.isNotEmpty()) {
+						val (messages, _) = initData
+						var sent = false
+						for (portNum in midiInputPorts.keys) {
+							Log.midiDetail("MIDI API: Sending init SysEx (${messages.size} messages) to port $portNum")
+							if (sendViaMidiApi(messages, portNum)) sent = true
+						}
+						if (sent) initSysExSent = true
+					}
+				} catch (e: RuntimeException) {
+					// Crashlytics 9b99a871: SecurityException from openInputPort on Android 16.
+					Log.err("MIDI API: init over MIDI API failed, falling back to USB", e)
+				}
+				// Let the SysEx flush before the ports are closed
+				delay(500)
+			} finally {
+				withContext(NonCancellable + Dispatchers.Main) {
+					closeMidiApi()
+					// A device that was torn down while we slept must not have its stale
+					// interface claimed for whatever is plugged in now.
+					if (connectionAtOpen != null && usbDeviceConnection === connectionAtOpen) claimUsbAndStart()
+				}
+			}
 		}
 	}
 
@@ -491,7 +562,63 @@ object MidiConnection {
 	private fun claimUsbAndStart() {
 		pendingUsbClaim?.invoke()
 		pendingUsbClaim = null
+		if (usbDeviceConnection == null) return
 		startSendLoop()
+		if (!initSysExSent) {
+			// The MIDI API path did not deliver the init SysEx (no MidiManager, no input port, or
+			// the open failed). driver.initialize() at assignment time was dropped because the
+			// connection did not exist yet, so without this the launchpad stays in its default
+			// layout and every pad lands on the wrong coordinate. It now goes over the bulk endpoint.
+			Log.midiDetail("USB: sending init SysEx over bulk transfer")
+			driver.initialize()
+		}
+	}
+
+	/** Releases the USB interface and fd, stops the loops, and clears every per-device field. */
+	private fun teardown(notify: Boolean) {
+		pendingInitJob?.cancel()
+		pendingInitJob = null
+		pendingUsbClaim = null
+		initSysExSent = false
+		closeMidiApi()
+		// Null the connection first: the receive loop and the send path compare against it.
+		val conn = usbDeviceConnection
+		usbDeviceConnection = null
+		val iface = usbInterface
+		usbInterface = null
+		usbEndpointIn = null
+		usbEndpointOut = null
+		if (conn != null) {
+			try {
+				if (iface != null) conn.releaseInterface(iface)
+			} catch (e: RuntimeException) {
+				Log.err("USB releaseInterface failed", e)
+			}
+			try {
+				conn.close()
+			} catch (e: RuntimeException) {
+				Log.err("USB close failed", e)
+			}
+		}
+		val hadDevice = conn != null || connectedDevice != null
+		isRun = false
+		if (notify && hadDevice) {
+			driver.onDisconnected()
+			connectedDevice = null
+			connectionObserver?.onDisconnected()
+		}
+	}
+
+	private fun looksLikeMidiDevice(device: UsbDevice): Boolean {
+		val pid = device.productId
+		if (driverRegistryExact.containsKey(pid)) return true
+		if (driverRegistryRanges.any { pid in it.pidStart..it.pidEnd }) return true
+		if (pid and MATRIX_PRODUCT_ID_MASK == MATRIX_PRODUCT_ID_BASE) return true
+		for (i in 0 until device.interfaceCount) {
+			val ui = device.getInterface(i)
+			if (ui.interfaceClass == UsbConstants.USB_CLASS_AUDIO && ui.interfaceSubclass == 3) return true
+		}
+		return false
 	}
 
 	private fun sendViaMidiApi(messages: List<ByteArray>, cableNumber: Int): Boolean {
@@ -528,12 +655,20 @@ object MidiConnection {
 				val encoded = encodeSysEx(msg, cableNumber)
 				Log.midiDetail("TX SysEx (USB): ${msg.joinToString(" ") { "%02X".format(it) }} (cable=$cableNumber)")
 
+				val conn = usbDeviceConnection
+				val ep = usbEndpointOut
+				if (conn == null || ep == null) {
+					Log.midiDetail("TX SysEx (USB): no connection, message dropped")
+					return
+				}
 				var offset = 0
 				while (offset < encoded.size) {
 					val chunk = minOf(64, encoded.size - offset)
-					usbDeviceConnection?.bulkTransfer(
-						usbEndpointOut, encoded, offset, chunk, USB_BULK_TIMEOUT_MS
-					)
+					val written = conn.bulkTransfer(ep, encoded, offset, chunk, USB_BULK_TIMEOUT_MS)
+					if (written < 0) {
+						Log.midiDetail("TX SysEx (USB): bulkTransfer failed ($written) at offset $offset")
+						return
+					}
 					offset += chunk
 				}
 				// Delay between SysEx messages to allow device mode transitions
@@ -585,91 +720,91 @@ object MidiConnection {
 		return packets.toByteArray()
 	}
 
-	private fun startReceiveLoop() {
-		receiveJob?.cancel()
+	private fun startReceiveLoop(conn: UsbDeviceConnection, endpointIn: UsbEndpoint) {
+		val previous = receiveJob
 		receiveJob = ioScope.launch {
+			// cancel() alone cannot interrupt a blocking bulkTransfer; wait for the old loop so two
+			// loops never poll the same endpoint. The old loop sees a foreign connection in its
+			// finally and stays silent, so the new device's "connected" is not followed by a bogus
+			// "disconnected".
+			previous?.cancelAndJoin()
+			if (usbDeviceConnection !== conn) return@launch
+
+			isRun = true
 			withContext(Dispatchers.Main) {
 				driver.onConnected()
 			}
+			Log.midiDetail("USB 시작")
 
-			if (!isRun) {
-				isRun = true
-				Log.midiDetail("USB 시작")
+			val byteArray = ByteArray(endpointIn.maxPacketSize)
+			// Flat int array: [cmd0,sig0,note0,vel0, cmd1,sig1,note1,vel1, ...]
+			val eventBuf = IntArray(endpointIn.maxPacketSize)
+			var fastFailures = 0
 
-				val endpointIn = usbEndpointIn ?: run {
-					Log.midiDetail("USB 에러 : usbEndpointIn == null")
-					isRun = false
-					return@launch
-				}
-
-				var prevTime = SystemClock.elapsedRealtime()
-				var count = 0
-				val byteArray = ByteArray(endpointIn.maxPacketSize)
-				// Flat int array: [cmd0,sig0,note0,vel0, cmd1,sig1,note1,vel1, ...]
-				val eventBuf = IntArray(endpointIn.maxPacketSize)
-
-				while (isRun) {
-					try {
-						val conn = usbDeviceConnection ?: break
-						val length = conn.bulkTransfer(
-							endpointIn,
-							byteArray,
-							byteArray.size,
-							1000
-						)
-						if (length >= 4) {
-							var eventCount = 0
-							var i = 0
-							while (i < length) {
-								val b1 = byteArray[i + 1].toInt() and 0xFF
-								if (b1 == 0xF8) { // Skip MIDI Clock
-									i += 4
-									continue
-								}
-								val base = eventCount * 4
-								eventBuf[base] = byteArray[i].toInt()
-								eventBuf[base + 1] = byteArray[i + 1].toInt()
-								eventBuf[base + 2] = byteArray[i + 2].toInt()
-								eventBuf[base + 3] = byteArray[i + 3].toInt()
-								eventCount++
+			try {
+				while (isActive && usbDeviceConnection === conn) {
+					val started = SystemClock.elapsedRealtime()
+					val length = conn.bulkTransfer(
+						endpointIn,
+						byteArray,
+						byteArray.size,
+						1000
+					)
+					if (length >= 4) {
+						fastFailures = 0
+						var eventCount = 0
+						var i = 0
+						// Whole 4-byte packets only: an interrupt endpoint with maxPacketSize 9
+						// can return a length that is not a multiple of 4.
+						while (i + 3 < length) {
+							val b1 = byteArray[i + 1].toInt() and 0xFF
+							if (b1 == 0xF8) { // Skip MIDI Clock
 								i += 4
+								continue
 							}
-							if (eventCount > 0) {
-								// Copy to snapshot for safe Main thread dispatch
-								val snapshot = eventBuf.copyOf(eventCount * 4)
-								val n = eventCount
-								withContext(Dispatchers.Main) {
-									for (j in 0 until n) {
-										val base = j * 4
-										driver.getSignal(snapshot[base], snapshot[base + 1], snapshot[base + 2], snapshot[base + 3])
-									}
+							val base = eventCount * 4
+							eventBuf[base] = byteArray[i].toInt()
+							eventBuf[base + 1] = byteArray[i + 1].toInt()
+							eventBuf[base + 2] = byteArray[i + 2].toInt()
+							eventBuf[base + 3] = byteArray[i + 3].toInt()
+							eventCount++
+							i += 4
+						}
+						if (eventCount > 0) {
+							// Copy to snapshot for safe Main thread dispatch
+							val snapshot = eventBuf.copyOf(eventCount * 4)
+							val n = eventCount
+							withContext(Dispatchers.Main) {
+								for (j in 0 until n) {
+									val base = j * 4
+									driver.getSignal(snapshot[base], snapshot[base + 1], snapshot[base + 2], snapshot[base + 3])
 								}
-							}
-						} else if (length == -1) {
-							val currTime = SystemClock.elapsedRealtime()
-							if (prevTime != currTime) {
-								count = 0
-								prevTime = currTime
-							} else {
-								count++
-								if (count > 10)
-									break
 							}
 						}
-					} catch (e: RuntimeException) {
-						Log.err("MIDI receive loop error", e)
-						break
+					} else if (length < 0) {
+						// An idle device also returns -1, but only after the full 1000 ms timeout;
+						// a detached device fails within a few milliseconds. Counting only the fast
+						// failures tells the two apart without depending on the same-millisecond
+						// coincidence the old heuristic needed (on ROMs where a dead fd takes
+						// >= 1 ms to fail it never fired and the loop spun forever).
+						if (SystemClock.elapsedRealtime() - started < 50) {
+							if (++fastFailures > 10) break
+						} else {
+							fastFailures = 0
+						}
 					}
 				}
-
+			} catch (e: CancellationException) {
+				throw e
+			} catch (e: RuntimeException) {
+				Log.err("MIDI receive loop error", e)
+			} finally {
 				Log.midiDetail("USB 끝")
-			}
-			isRun = false
-
-			withContext(Dispatchers.Main) {
-				driver.onDisconnected()
-				connectedDevice = null
-				connectionObserver?.onDisconnected()
+				withContext(NonCancellable + Dispatchers.Main) {
+					// Only the loop that still owns the connection reports the disconnect;
+					// a superseded loop's device has already been torn down by initDevice.
+					if (usbDeviceConnection === conn) teardown(notify = true)
+				}
 			}
 		}
 	}

--- a/app/src/main/java/com/kimjisub/launchpad/midi/driver/LaunchpadMK2.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/driver/LaunchpadMK2.kt
@@ -41,6 +41,10 @@ class LaunchpadMK2 : DriverRef() {
 	}
 
 	override fun sendPadLed(x: Int, y: Int, velocity: Int) {
+		// x/y come from the pack's info file (buttonX/buttonY) and are not clamped upstream; an
+		// out-of-grid pad would address the ring, or on a 16-note layout put a status byte in a
+		// data position.
+		if (x !in 0..7 || y !in 0..7) return
 		sendSignal(9, -112, 10 * (8 - x) + y + 1, velocity)
 	}
 

--- a/app/src/main/java/com/kimjisub/launchpad/midi/driver/LaunchpadMK3.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/driver/LaunchpadMK3.kt
@@ -58,10 +58,10 @@ class LaunchpadMK3 : DriverRef() {
 		if (cmd == 9) {
 			val x = 9 - note / 10
 			val y = note % 10
-			if (y in 1..8)
+			// Notes 91..98 (x = 0) are the top row and would map to pad row -1 (same as #52 in MK2).
+			if (x in 1..8 && y in 1..8)
 				onPadTouch(x - 1, y - 1, velocity != 0, velocity)
-		}
-		if (cmd == 11 && sig == -80) {
+		} else if (cmd == 11 && sig == -80) {
 			if (note in 91..98) {
 				onFunctionKeyTouch(note - 91, velocity != 0)
 			}
@@ -94,11 +94,16 @@ class LaunchpadMK3 : DriverRef() {
 	}
 
 	override fun sendPadLed(x: Int, y: Int, velocity: Int) {
+		// x/y come from the pack's info file (buttonX/buttonY) and are not clamped upstream; an
+		// out-of-grid pad would address the ring, or on a 16-note layout put a status byte in a
+		// data position.
+		if (x !in 0..7 || y !in 0..7) return
 		sendSignal(9, -112, 10 * (8 - x) + y + 1, velocity)
 	}
 
 	override fun sendChainLed(c: Int, velocity: Int) {
-		if (c in 0..7)
+		// getSignal reports chains 0..23 (right column, bottom row, left column)
+		if (c in 0..23)
 			sendFunctionKeyLed(c + 8, velocity)
 	}
 

--- a/app/src/main/java/com/kimjisub/launchpad/midi/driver/LaunchpadPRO.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/driver/LaunchpadPRO.kt
@@ -62,10 +62,10 @@ class LaunchpadPRO : DriverRef() {
 		if (cmd == 9) {
 			val x = 9 - note / 10
 			val y = note % 10
-			if (y in 1..8)
+			// Notes 91..98 (x = 0) are the top row and would map to pad row -1 (same as #52 in MK2).
+			if (x in 1..8 && y in 1..8)
 				onPadTouch(x - 1, y - 1, velocity != 0, velocity)
-		}
-		if (cmd == 11 && sig == -80) {
+		} else if (cmd == 11 && sig == -80) {
 			if (note in 91..98) {
 				onFunctionKeyTouch(note - 91, velocity != 0)
 			}
@@ -98,11 +98,16 @@ class LaunchpadPRO : DriverRef() {
 	}
 
 	override fun sendPadLed(x: Int, y: Int, velocity: Int) {
+		// x/y come from the pack's info file (buttonX/buttonY) and are not clamped upstream; an
+		// out-of-grid pad would address the ring, or on a 16-note layout put a status byte in a
+		// data position.
+		if (x !in 0..7 || y !in 0..7) return
 		sendSignal(9, -112, 10 * (8 - x) + y + 1, velocity)
 	}
 
 	override fun sendChainLed(c: Int, velocity: Int) {
-		if (c in 0..7)
+		// getSignal reports chains 0..23 (right column, bottom row, left column)
+		if (c in 0..23)
 			sendFunctionKeyLed(c + 8, velocity)
 	}
 

--- a/app/src/main/java/com/kimjisub/launchpad/midi/driver/LaunchpadPROCFW.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/driver/LaunchpadPROCFW.kt
@@ -27,9 +27,13 @@ class LaunchpadPROCFW : DriverRef() {
 
 	override fun getSignal(cmd: Int, sig: Int, note: Int, velocity: Int) {
 		val cin = cmd and 0x0F
-		if (cin != 8 && cin != 9 && cin != 11) return
+		if (cin != 8 && cin != 9 && cin != 11) {
+			// PlayActivity's Live Mode resync hook listens here, as it does for PRO/MK3.
+			onUnknownReceived(cmd, sig, note, velocity)
+			return
+		}
 
-		val isDown = (cin == 9 && velocity > 0) || (cin == 11 && velocity > 0)
+		val isDown = cin != 8 && velocity > 0
 
 		when (note) {
 			in 36..99 -> {
@@ -72,6 +76,10 @@ class LaunchpadPROCFW : DriverRef() {
 	}
 
 	override fun sendPadLed(x: Int, y: Int, velocity: Int) {
+		// x/y come from the pack's info file (buttonX/buttonY) and are not clamped upstream; an
+		// out-of-grid pad would address the ring, or on a 16-note layout put a status byte in a
+		// data position.
+		if (x !in 0..7 || y !in 0..7) return
 		// UniPad passes x as row, y as col
 		val rowInverted = 7 - x
 		val note = if (y < 4) {

--- a/app/src/main/java/com/kimjisub/launchpad/midi/driver/LaunchpadS.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/driver/LaunchpadS.kt
@@ -41,8 +41,15 @@ class LaunchpadS : DriverRef() {
 	}
 
 	override fun sendPadLed(x: Int, y: Int, velocity: Int) {
-		sendSignal(9, -112, x * 16 + y, LaunchpadColor.SCode[velocity])
+		// x/y come from the pack's info file (buttonX/buttonY) and are not clamped upstream; an
+		// out-of-grid pad would address the ring, or on a 16-note layout put a status byte in a
+		// data position.
+		if (x !in 0..7 || y !in 0..7) return
+		sendSignal(9, -112, x * 16 + y, sCode(velocity))
 	}
+
+	// velocity is a LED code read out of a pack; SCode has 128 entries.
+	private fun sCode(velocity: Int): Int = LaunchpadColor.SCode[velocity.coerceIn(0, LaunchpadColor.SCode.lastIndex)]
 
 	override fun sendChainLed(c: Int, velocity: Int) {
 		if (c in 0..7)
@@ -55,7 +62,7 @@ class LaunchpadS : DriverRef() {
 				circleCode[f][0].toByte(),
 				circleCode[f][1].toByte(),
 				circleCode[f][2].toByte(),
-				LaunchpadColor.SCode[velocity].toByte()
+				sCode(velocity).toByte()
 			)
 	}
 

--- a/app/src/main/java/com/kimjisub/launchpad/midi/driver/LaunchpadX.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/driver/LaunchpadX.kt
@@ -79,11 +79,16 @@ open class LaunchpadX : DriverRef() {
 	}
 
 	override fun sendPadLed(x: Int, y: Int, velocity: Int) {
+		// x/y come from the pack's info file (buttonX/buttonY) and are not clamped upstream; an
+		// out-of-grid pad would address the ring, or on a 16-note layout put a status byte in a
+		// data position.
+		if (x !in 0..7 || y !in 0..7) return
 		sendSignal(25, -112, 10 * (8 - x) + y + 1, velocity)
 	}
 
 	override fun sendChainLed(c: Int, velocity: Int) {
-		if (c in 0..7)
+		// getSignal reports chains 0..23 (right column, bottom row, left column)
+		if (c in 0..23)
 			sendFunctionKeyLed(c + 8, velocity)
 	}
 

--- a/app/src/main/java/com/kimjisub/launchpad/midi/driver/MasterKeyboard.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/driver/MasterKeyboard.kt
@@ -14,7 +14,9 @@ class MasterKeyboard : DriverRef() {
 				y = 8 - (99 - note) % 4
 				onPadTouch(x - 1, y - 1, velocity != 0, velocity)
 			}
-		} else if (velocity == 0) {
+		} else if (cmd == 8) {
+			// Keyed on the command, not the data byte: a CC with value 0 used to release a pad, and a
+			// note-off with a release velocity was ignored and left the pad stuck.
 			if (note in 36..67) {
 				x = (67 - note) / 4 + 1
 				y = 4 - (67 - note) % 4

--- a/app/src/main/java/com/kimjisub/launchpad/midi/driver/Matrix.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/driver/Matrix.kt
@@ -43,24 +43,36 @@ class Matrix : DriverRef() {
 		val y: Int
 		when (cmd) {
 			9 -> when (note) {
+				// A note-on with velocity 0 is a release; treating it as a press latched the pad.
 				in 36..67 -> {
 					x = (67 - note) / 4 + 1
 					y = 4 - (67 - note) % 4
-					onPadTouch(x - 1, y - 1, true, velocity)
+					onPadTouch(x - 1, y - 1, velocity != 0, velocity)
 				}
 				in 68..99 -> {
 					x = (99 - note) / 4 + 1
 					y = 8 - (99 - note) % 4
-					onPadTouch(x - 1, y - 1, true, velocity)
+					onPadTouch(x - 1, y - 1, velocity != 0, velocity)
+				}
+				// Ring banks mirror circleCode: top 28..35 (f 0..7), right 100..107 (f 8..15),
+				// bottom 123..116 (f 16..23), left 115..108 (f 24..31).
+				in 28..35 -> {
+					onFunctionKeyTouch(note - 28, velocity != 0)
 				}
 				in 100..107 -> {
 					val c = note - 100
 					onChainTouch(c, velocity != 0)
 					onFunctionKeyTouch(c + 8, velocity != 0)
 				}
+				in 116..123 -> {
+					val f = 16 + (123 - note)
+					onChainTouch(f - 8, velocity != 0)
+					onFunctionKeyTouch(f, velocity != 0)
+				}
 				in 108..115 -> {
-					val c = 8 - (note - 108) + 8
-					onFunctionKeyTouch(c + 8, velocity != 0)
+					val f = 24 + (115 - note)
+					onChainTouch(f - 8, velocity != 0)
+					onFunctionKeyTouch(f, velocity != 0)
 				}
 			}
 			8 -> when (note) {
@@ -79,6 +91,10 @@ class Matrix : DriverRef() {
 	}
 
 	override fun sendPadLed(x: Int, y: Int, velocity: Int) {
+		// x/y come from the pack's info file (buttonX/buttonY) and are not clamped upstream; an
+		// out-of-grid pad would address the ring, or on a 16-note layout put a status byte in a
+		// data position.
+		if (x !in 0..7 || y !in 0..7) return
 		val padX = x + 1
 		val padY = y + 1
 		if (padY in 1..4) {
@@ -89,7 +105,7 @@ class Matrix : DriverRef() {
 	}
 
 	override fun sendChainLed(c: Int, velocity: Int) {
-		if (c in 0..7)
+		if (c in 0..23)
 			sendFunctionKeyLed(c + 8, velocity)
 	}
 
@@ -107,5 +123,8 @@ class Matrix : DriverRef() {
 		for (i in 0..7)
 			for (j in 0..7)
 				sendPadLed(i, j, 0)
+		// The ring stayed lit after leaving PlayActivity or switching drivers.
+		for (i in 0..31)
+			sendFunctionKeyLed(i, 0)
 	}
 }

--- a/app/src/main/java/com/kimjisub/launchpad/midi/driver/MidiFighter.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/driver/MidiFighter.kt
@@ -8,11 +8,11 @@ class MidiFighter : DriverRef() {
 			if (note in 36..67) {
 				x = (67 - note) / 4 + 1
 				y = 4 - (67 - note) % 4
-				onPadTouch(x - 1, y - 1, true, velocity)
+				onPadTouch(x - 1, y - 1, velocity != 0, velocity)
 			} else if (note in 68..99) {
 				x = (99 - note) / 4 + 1
 				y = 8 - (99 - note) % 4
-				onPadTouch(x - 1, y - 1, true, velocity)
+				onPadTouch(x - 1, y - 1, velocity != 0, velocity)
 			}
 		} else if (cmd == 8) {
 			if (note in 36..67) {
@@ -28,6 +28,10 @@ class MidiFighter : DriverRef() {
 	}
 
 	override fun sendPadLed(x: Int, y: Int, velocity: Int) {
+		// x/y come from the pack's info file (buttonX/buttonY) and are not clamped upstream; an
+		// out-of-grid pad would address the ring, or on a 16-note layout put a status byte in a
+		// data position.
+		if (x !in 0..7 || y !in 0..7) return
 		val padX = x + 1
 		val padY = y + 1
 		if (padY in 1..4) {

--- a/app/src/main/res/xml/device_filter.xml
+++ b/app/src/main/res/xml/device_filter.xml
@@ -32,6 +32,6 @@
 	<usb-device vendor-id="6860" />
 	<usb-device vendor-id="7427" />
 	<usb-device vendor-id="7447" />
-	<usb-device vendor-id="5636" />
+	<usb-device vendor-id="4661" />
 	<usb-device vendor-id="64520" />
 </resources>

--- a/app/src/test/java/com/kimjisub/launchpad/midi/driver/LaunchpadMK3Test.kt
+++ b/app/src/test/java/com/kimjisub/launchpad/midi/driver/LaunchpadMK3Test.kt
@@ -133,6 +133,34 @@ class LaunchpadMK3Test {
 		verify { receiveListener.onUnknownReceived(99, 0, 0, 0) }
 	}
 
+	@Test
+	fun getSignal_topRowNote_doesNotReachPads() {
+		// note 91..98 → x = 0: used to call onPadTouch(-1, ...)
+		driver.getSignal(cmd = 9, sig = 0, note = 91, velocity = 100)
+		verify(exactly = 0) { receiveListener.onPadTouch(any(), any(), any(), any()) }
+		verify(exactly = 0) { receiveListener.onUnknownReceived(any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun getSignal_padNote_isNotReportedAsUnknown() {
+		driver.getSignal(cmd = 9, sig = 0, note = 81, velocity = 100)
+		verify(exactly = 0) { receiveListener.onUnknownReceived(any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun sendChainLed_bottomRow_routesToFunctionKey() {
+		// chain 8 → f 16 → circleCode[16] = {11, -80, 8}
+		driver.sendChainLed(8, 60)
+		verify { sendListener.onSend(11.toByte(), (-80).toByte(), 8.toByte(), 60.toByte()) }
+	}
+
+	@Test
+	fun sendPadLed_outOfGrid_doesNotSend() {
+		driver.sendPadLed(8, 0, 60)
+		driver.sendPadLed(0, -1, 60)
+		verify(exactly = 0) { sendListener.onSend(any(), any(), any(), any()) }
+	}
+
 	// --- sendPadLed ---
 
 	@Test
@@ -160,7 +188,7 @@ class LaunchpadMK3Test {
 
 	@Test
 	fun sendChainLed_outOfRange_doesNotSend() {
-		driver.sendChainLed(8, 60)
+		driver.sendChainLed(24, 60)
 		verify(exactly = 0) { sendListener.onSend(any(), any(), any(), any()) }
 	}
 

--- a/app/src/test/java/com/kimjisub/launchpad/midi/driver/LaunchpadPROTest.kt
+++ b/app/src/test/java/com/kimjisub/launchpad/midi/driver/LaunchpadPROTest.kt
@@ -124,6 +124,25 @@ class LaunchpadPROTest {
 	}
 
 	@Test
+	fun getSignal_topRowNote_doesNotReachPads() {
+		// note 91..98 → x = 0: used to call onPadTouch(-1, ...) (MainActivity forwarded it to sendPadLed)
+		driver.getSignal(cmd = 9, sig = 0, note = 98, velocity = 100)
+		verify(exactly = 0) { receiveListener.onPadTouch(any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun getSignal_padNote_isNotReportedAsUnknown() {
+		driver.getSignal(cmd = 9, sig = 0, note = 81, velocity = 100)
+		verify(exactly = 0) { receiveListener.onUnknownReceived(any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun sendPadLed_outOfGrid_doesNotSend() {
+		driver.sendPadLed(0, 8, 60)
+		verify(exactly = 0) { sendListener.onSend(any(), any(), any(), any()) }
+	}
+
+	@Test
 	fun getSignal_unknownSignal_callsUnknownReceived() {
 		driver.getSignal(cmd = 99, sig = 0, note = 0, velocity = 0)
 		verify { receiveListener.onUnknownReceived(99, 0, 0, 0) }

--- a/app/src/test/java/com/kimjisub/launchpad/midi/driver/LaunchpadSTest.kt
+++ b/app/src/test/java/com/kimjisub/launchpad/midi/driver/LaunchpadSTest.kt
@@ -115,6 +115,22 @@ class LaunchpadSTest {
 		verify { sendListener.onSend(9.toByte(), (-112).toByte(), 119.toByte(), LaunchpadColor.SCode[127].toByte()) }
 	}
 
+	@Test
+	fun sendPadLed_codeOutsidePalette_isClamped() {
+		// a pack LED code of 200 used to throw ArrayIndexOutOfBounds inside the driver
+		driver.sendPadLed(0, 0, 200)
+		verify { sendListener.onSend(9.toByte(), (-112).toByte(), 0.toByte(), LaunchpadColor.SCode[127].toByte()) }
+		driver.sendPadLed(0, 1, -3)
+		verify { sendListener.onSend(9.toByte(), (-112).toByte(), 1.toByte(), LaunchpadColor.SCode[0].toByte()) }
+	}
+
+	@Test
+	fun sendPadLed_outOfGrid_doesNotSend() {
+		// (8, 0) would be note 128 = 0x80, a status byte in a data position
+		driver.sendPadLed(8, 0, 60)
+		verify(exactly = 0) { sendListener.onSend(any(), any(), any(), any()) }
+	}
+
 	// --- sendChainLed ---
 
 	@Test

--- a/app/src/test/java/com/kimjisub/launchpad/midi/driver/MasterKeyboardTest.kt
+++ b/app/src/test/java/com/kimjisub/launchpad/midi/driver/MasterKeyboardTest.kt
@@ -62,16 +62,24 @@ class MasterKeyboardTest {
 	// --- getSignal: note-off via velocity==0 with non-cmd-9 ---
 
 	@Test
-	fun getSignal_nonCmd9_velocityZero_lowerRange() {
-		// cmd=10, velocity=0 → note-off path
-		driver.getSignal(cmd = 10, sig = 0, note = 36, velocity = 0)
+	fun getSignal_noteOff_lowerRange() {
+		// cmd=8 → note-off path
+		driver.getSignal(cmd = 8, sig = 0, note = 36, velocity = 0)
 		verify { receiveListener.onPadTouch(7, 0, false, 0) }
 	}
 
 	@Test
-	fun getSignal_nonCmd9_velocityZero_upperRange() {
-		driver.getSignal(cmd = 10, sig = 0, note = 99, velocity = 0)
+	fun getSignal_noteOff_upperRange_withReleaseVelocity() {
+		// a note-off carrying a release velocity used to be ignored and left the pad stuck
+		driver.getSignal(cmd = 8, sig = 0, note = 99, velocity = 64)
 		verify { receiveListener.onPadTouch(0, 7, false, 0) }
+	}
+
+	@Test
+	fun getSignal_controlChangeWithZeroValue_noAction() {
+		// a CC (cmd=11) with value 0 and a controller number in the pad range is not a pad release
+		driver.getSignal(cmd = 11, sig = 0, note = 36, velocity = 0)
+		verify(exactly = 0) { receiveListener.onPadTouch(any(), any(), any(), any()) }
 	}
 
 	// --- getSignal: non-cmd-9 with non-zero velocity → no action ---

--- a/app/src/test/java/com/kimjisub/launchpad/midi/driver/MatrixTest.kt
+++ b/app/src/test/java/com/kimjisub/launchpad/midi/driver/MatrixTest.kt
@@ -77,20 +77,52 @@ class MatrixTest {
 		verify { receiveListener.onFunctionKeyTouch(8, false) }
 	}
 
-	// --- getSignal: note-on (cmd=9) extra function keys (108-115) ---
+	// --- getSignal: ring banks round-trip with circleCode ---
 
 	@Test
-	fun getSignal_extraFunctionKey_first() {
-		// note=108: c=8-(108-108)+8=16 → functionKey(16+8=24)
-		driver.getSignal(cmd = 9, sig = 0, note = 108, velocity = 127)
-		verify { receiveListener.onFunctionKeyTouch(24, true) }
+	fun getSignal_topRow_matchesCircleCode() {
+		// circleCode[0] = 28, circleCode[7] = 35
+		driver.getSignal(cmd = 9, sig = 0, note = 28, velocity = 127)
+		verify { receiveListener.onFunctionKeyTouch(0, true) }
+		driver.getSignal(cmd = 9, sig = 0, note = 35, velocity = 127)
+		verify { receiveListener.onFunctionKeyTouch(7, true) }
 	}
 
 	@Test
-	fun getSignal_extraFunctionKey_last() {
-		// note=115: c=8-(115-108)+8=9 → functionKey(9+8=17)
+	fun getSignal_bottomRow_matchesCircleCode() {
+		// circleCode[16] = 123 (chain 8), circleCode[23] = 116 (chain 15)
+		driver.getSignal(cmd = 9, sig = 0, note = 123, velocity = 127)
+		verify { receiveListener.onChainTouch(8, true) }
+		verify { receiveListener.onFunctionKeyTouch(16, true) }
+		driver.getSignal(cmd = 9, sig = 0, note = 116, velocity = 127)
+		verify { receiveListener.onChainTouch(15, true) }
+		verify { receiveListener.onFunctionKeyTouch(23, true) }
+	}
+
+	@Test
+	fun getSignal_leftColumn_matchesCircleCode() {
+		// circleCode[24] = 115 (chain 16), circleCode[31] = 108 (chain 23)
 		driver.getSignal(cmd = 9, sig = 0, note = 115, velocity = 127)
-		verify { receiveListener.onFunctionKeyTouch(17, true) }
+		verify { receiveListener.onChainTouch(16, true) }
+		verify { receiveListener.onFunctionKeyTouch(24, true) }
+		driver.getSignal(cmd = 9, sig = 0, note = 108, velocity = 127)
+		verify { receiveListener.onChainTouch(23, true) }
+		verify { receiveListener.onFunctionKeyTouch(31, true) }
+	}
+
+	@Test
+	fun getSignal_everyRingNote_lightsTheSameButton() {
+		for (f in 0..31) {
+			val note = Matrix.circleCode[f][2]
+			driver.getSignal(cmd = 9, sig = 0, note = note, velocity = 127)
+			verify { receiveListener.onFunctionKeyTouch(f, true) }
+		}
+	}
+
+	@Test
+	fun getSignal_noteOnVelocityZero_isRelease() {
+		driver.getSignal(cmd = 9, sig = 0, note = 36, velocity = 0)
+		verify { receiveListener.onPadTouch(7, 0, false, 0) }
 	}
 
 	// --- getSignal: note-off (cmd=8) ---
@@ -133,9 +165,31 @@ class MatrixTest {
 	}
 
 	@Test
-	fun sendChainLed_outOfRange_doesNotSend() {
+	fun sendChainLed_bottomRow_routesToFunctionKey() {
+		// chain 8 → f 16 → circleCode[16] = {9, -111, 123}
 		driver.sendChainLed(8, 60)
+		verify { sendListener.onSend(9.toByte(), (-111).toByte(), 123.toByte(), 60.toByte()) }
+	}
+
+	@Test
+	fun sendChainLed_outOfRange_doesNotSend() {
+		driver.sendChainLed(24, 60)
 		verify(exactly = 0) { sendListener.onSend(any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun sendPadLed_outOfGrid_doesNotSend() {
+		driver.sendPadLed(8, 0, 60)
+		driver.sendPadLed(0, 8, 60)
+		driver.sendPadLed(-1, 0, 60)
+		verify(exactly = 0) { sendListener.onSend(any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun sendClearLed_clearsRingToo() {
+		driver.sendClearLed()
+		// 64 pads + 32 ring buttons
+		verify(exactly = 96) { sendListener.onSend(any(), any(), any(), 0.toByte()) }
 	}
 
 	// --- sendFunctionKeyLed ---

--- a/app/src/test/java/com/kimjisub/launchpad/midi/driver/MidiFighterTest.kt
+++ b/app/src/test/java/com/kimjisub/launchpad/midi/driver/MidiFighterTest.kt
@@ -55,6 +55,18 @@ class MidiFighterTest {
 	// --- getSignal: note-off (cmd=8) ---
 
 	@Test
+	fun getSignal_noteOnVelocityZero_isRelease() {
+		driver.getSignal(cmd = 9, sig = 0, note = 36, velocity = 0)
+		verify { receiveListener.onPadTouch(7, 0, false, 0) }
+	}
+
+	@Test
+	fun sendPadLed_outOfGrid_doesNotSend() {
+		driver.sendPadLed(8, 0, 60)
+		verify(exactly = 0) { sendListener.onSend(any(), any(), any(), any()) }
+	}
+
+	@Test
 	fun getSignal_noteOff_lowerRange() {
 		// cmd=8 → upDown=false
 		driver.getSignal(cmd = 8, sig = 0, note = 36, velocity = 0)


### PR DESCRIPTION
## What

Fixes the blocker and major findings from the whole-repo review of the MIDI layer (`MidiConnection`, drivers, USB handler). Full review notes live in the private workspace repo under `design/2026-09-07/reviews/android-midi-drivers.md`.

### MidiConnection
- MIDI API enumeration (`getDevices`, `properties`, `ports`) is now inside the try that #41/#49 added only around `openDevice`; the same Android 16 MIDI service failure reached `UsbMidiHandlerActivity.onCreate` through it.
- `UsbManager.openDevice` is preceded by `hasPermission` and wrapped, so an ungranted device no longer throws `SecurityException` out of `onCreate`.
- Port opening and the init SysEx sends (blocking `send` + 50 ms sleeps per message per port) run on the IO scope instead of the main thread. The job is owned and cancelled by `teardown()`.
- New `teardown()`: `releaseInterface`, close the fd, clear every per-device field, cancel the pending init, report the disconnect. Called at the head of `initDevice` (replug), when `claimInterface` fails, and when the receive loop ends. Before this nothing ever closed a `UsbDeviceConnection`.
- Receive loop: waits for the previous loop (`cancelAndJoin`), runs while `isActive` and the connection is still the one it started with, rethrows `CancellationException`, tears down in a `NonCancellable` finally, reads whole 4-byte packets only, and detects a detached device by fast `-1` results instead of a same-millisecond coincidence.
- The init SysEx goes over the bulk endpoint when the MIDI API path did not deliver it. It used to be sent to a null listener before the connection existed, so on that path the Launchpad stayed in its default layout.

### Drivers
- `LaunchpadPRO` / `LaunchpadMK3`: `x in 1..8` guard (top-row notes reached pad row -1, as #52 fixed for MK2); CC branch chained with `else if` so pad notes are not reported as unknown events; `sendChainLed` accepts 0..23.
- `Matrix`: note-on velocity 0 is a release; left column maps to the buttons `circleCode` lights (108 -> f31, 115 -> f24) and reports chains; top row 28..35 and bottom row 116..123 handled; `sendClearLed` clears the ring.
- `MasterKeyboard`: note-off keyed on cmd 8 instead of velocity 0.
- `MidiFighter`: note-on velocity 0 is a release.
- `LaunchpadS`: `SCode` index clamped to 0..127.
- `LaunchpadPROCFW`: unknown messages reach `onUnknownReceived`.
- Every `sendPadLed` rejects coordinates outside 0..7.

### Other
- `UsbMidiHandlerActivity`: `onNewIntent` handles a second attach; `UsbManager` cast is safe.
- Manifest declares `android.hardware.usb.host` (`required=false`) instead of an intent action; `device_filter.xml` adds Novation's vendor id (4661) and drops a duplicate.

## Verification

| Check | Result |
|---|---|
| `:app:compileDebugKotlin` | ok |
| `:app:testDebugUnitTest` | 279 / 279 (14 driver tests added, 5 updated for the corrected mappings) |
| `:app:lintDebug` | 0 errors |

Not verified on hardware in this PR: the receive-loop rewrite and the USB init-SysEx fallback need a real Launchpad plugged in. The driver note-map changes are covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)