### PR TITLE
fix(app): close the data-loss blockers of the 2026-09-07 app-layer review

### DIFF
--- a/app/proguard-common.pro
+++ b/app/proguard-common.pro
@@ -10,6 +10,9 @@
 # GSON
 -keepattributes *Annotation*
 -keep class com.google.gson.** { *; }
+# Gson models without @SerializedName: R8 renamed the fields, so every unipad:// import got a
+# UnishareVO with null fields and downloaded .../unishare/null/download in release builds.
+-keep class com.kimjisub.launchpad.api.**.vo.** { *; }
 
 -keep class com.kimjisub.launchpad.activity.MainActivity { *; }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
 		tools:ignore="ScopedStorage" />
 
 	<uses-permission android:name="android.permission.WAKE_LOCK" />
+	<!-- Download/import progress notifications; without it they are dropped on Android 13+ -->
+	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 	<application
 		android:name=".BaseApplication"

--- a/app/src/main/java/com/kimjisub/launchpad/activity/BaseActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/BaseActivity.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.media.AudioManager
 import android.os.Build
 import android.os.Bundle
-import android.os.Process
 import androidx.appcompat.app.AppCompatActivity
 import com.kimjisub.launchpad.R.anim
 import com.kimjisub.launchpad.db.repository.UnipackRepository
@@ -58,13 +57,18 @@ open class BaseActivity : AppCompatActivity() {
 		}
 
 		fun restartApp(activity: BaseActivity) {
+			printActivityLog("${activity.getActivityName()} requestRestart")
 			for (a in activities.asReversed()) {
 				a.finish()
 			}
 			activities.clear()
-			activity.start<MainActivity>()
-			printActivityLog("${activity.getActivityName()} requestRestart")
-			Process.killProcess(Process.myPid())
+			// A plain start followed by killProcess left the launcher with a dead task and no app.
+			// makeRestartActivityTask clears the task and the system relaunches the process for it.
+			val intent = Intent.makeRestartActivityTask(
+				android.content.ComponentName(activity, MainActivity::class.java)
+			)
+			activity.startActivity(intent)
+			Runtime.getRuntime().exit(0)
 		}
 	}
 

--- a/app/src/main/java/com/kimjisub/launchpad/activity/FBStoreActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/FBStoreActivity.kt
@@ -79,6 +79,8 @@ import java.text.NumberFormat
 class StoreItemState(
 	storeVO: StoreVO,
 	downloaded: Boolean = false,
+	/** Firebase child key: unique per entry, unlike the server-controlled, nullable `code`. */
+	val key: String = storeVO.code ?: "",
 ) {
 	var storeVO by mutableStateOf(storeVO)
 	var downloaded by mutableStateOf(downloaded)
@@ -153,7 +155,9 @@ class FBStoreActivity : BaseActivity() {
 				try {
 					val d: StoreVO = dataSnapshot.getValue(StoreVO::class.java) ?: return
 					val isDownloaded = downloadList.any { it.unipack.id == d.code }
-					storeItems.add(0, StoreItemState(d, isDownloaded))
+					val key = dataSnapshot.key ?: d.code ?: return
+					if (storeItems.any { it.key == key }) return
+					storeItems.add(0, StoreItemState(d, isDownloaded, key))
 				} catch (e: RuntimeException) {
 					Log.err("onChildAdded failed", e)
 				}
@@ -404,7 +408,8 @@ private fun StoreScreen(
 				) {
 					itemsIndexed(
 						storeItems,
-						key = { index, item -> item.storeVO.code ?: index },
+						// Two entries sharing a code (or two null codes) crashed the list with duplicate keys.
+						key = { _, item -> item.key },
 					) { _, item ->
 						StorePackListItem(
 							item = item,

--- a/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
@@ -234,11 +234,13 @@ class PlayActivity : BaseActivity() {
 		}
 
 		override fun startGuideAnimation(x: Int, y: Int, targetWallTimeMs: Long) {
-			padViews[x][y]?.startGuideAnimation(targetWallTimeMs)
+			if (!::padViews.isInitialized) return
+			padViews.getOrNull(x)?.getOrNull(y)?.startGuideAnimation(targetWallTimeMs)
 		}
 
 		override fun stopGuideAnimation(x: Int, y: Int) {
-			padViews[x][y]?.stopGuideAnimation()
+			if (!::padViews.isInitialized) return
+			padViews.getOrNull(x)?.getOrNull(y)?.stopGuideAnimation()
 		}
 
 		override fun sendGuideLedToLaunchpad(x: Int, y: Int, velocity: Int) {
@@ -960,7 +962,9 @@ class PlayActivity : BaseActivity() {
 			vm.uiLoaded = true
 			vm.refreshWatermark()
 			updateVolumeUI()
-			controller = midiController
+			// initLayout runs from a posted runnable; if onPause already removed the controller,
+			// re-registering here would leave a paused activity receiving MIDI. onResume re-adds it.
+			if (lifecycle.currentState.isAtLeast(androidx.lifecycle.Lifecycle.State.RESUMED)) controller = midiController
 		} catch (e: RuntimeException) {
 			Log.err("initLayout failed", e)
 		}

--- a/app/src/main/java/com/kimjisub/launchpad/activity/SplashActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/SplashActivity.kt
@@ -49,6 +49,12 @@ class SplashActivity : BaseActivity() {
 	// Timer
 	private var splashJob: Job? = null
 	private var showPermissionDialog by mutableStateOf(false)
+	private var permissionsDone = false
+
+	// Notifications are optional: whatever the answer, the app proceeds.
+	private val notificationPermissionLauncher = registerForActivityResult(
+		ActivityResultContracts.RequestPermission()
+	) { proceedToMain() }
 
 	// Permission request launcher
 	private val permissionLauncher = registerForActivityResult(
@@ -100,7 +106,13 @@ class SplashActivity : BaseActivity() {
 		// Android 11+ (API 30+): No runtime storage permission needed
 		// App uses getExternalFilesDir() (no permission) + SAF for Documents access
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-			proceedToMain()
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+				ContextCompat.checkSelfPermission(this, permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+			) {
+				notificationPermissionLauncher.launch(permission.POST_NOTIFICATIONS)
+			} else {
+				proceedToMain()
+			}
 			return
 		}
 
@@ -124,11 +136,18 @@ class SplashActivity : BaseActivity() {
 	}
 
 	private fun proceedToMain() {
+		permissionsDone = true
 		splashJob = lifecycleScope.launch {
 			delay(SPLASH_DISPLAY_TIME_MS)
 			finish()
 			start<MainActivity>()
 		}
+	}
+
+	override fun onStart() {
+		super.onStart()
+		// onStop cancels the delay; coming back used to leave the app on the splash forever.
+		if (permissionsDone && splashJob?.isActive != true) proceedToMain()
 	}
 
 	override fun onStop() {

--- a/app/src/main/java/com/kimjisub/launchpad/manager/FileManager.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/manager/FileManager.kt
@@ -213,14 +213,19 @@ object FileManager {
 				copyFileToDocumentTree(context, child, dirDoc)
 			}
 		} else {
-			val mimeType = when (source.extension.lowercase()) {
-				"wav" -> "audio/wav"; "mp3" -> "audio/mpeg"; "ogg" -> "audio/ogg"
-				else -> "application/octet-stream"
-			}
-			val fileDoc = targetParent.createFile(mimeType, source.nameWithoutExtension) ?: return
+			// The provider derives the stored name from (mimeType, displayName): it keeps the name
+			// when the extension already matches the type and appends one otherwise. Passing the
+			// name without its extension lost every ".m4a"/".json" and keySound could no longer
+			// find the sounds; the mime type is therefore looked up from the real extension and
+			// the full name is passed, which leaves "info", "keySound", "clip.m4a" untouched.
+			val mimeType = android.webkit.MimeTypeMap.getSingleton()
+				.getMimeTypeFromExtension(source.extension.lowercase())
+				?: "application/octet-stream"
+			val fileDoc = targetParent.createFile(mimeType, source.name)
+				?: throw IOException("Could not create ${source.name} in ${targetParent.uri}")
 			context.contentResolver.openOutputStream(fileDoc.uri)?.use { output ->
 				source.inputStream().use { input -> input.copyTo(output, COPY_BUFFER_SIZE) }
-			}
+			} ?: throw IOException("Could not open ${fileDoc.uri} for writing")
 		}
 	}
 }

--- a/app/src/main/java/com/kimjisub/launchpad/manager/WorkspaceManager.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/manager/WorkspaceManager.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import com.kimjisub.launchpad.R
+import com.kimjisub.launchpad.tool.Log
 import java.io.File
 
 class WorkspaceManager(val context: Context) : KoinComponent {
@@ -60,11 +61,17 @@ class WorkspaceManager(val context: Context) : KoinComponent {
 				)
 			}
 
-			// External SD cards only (skip internal storage which duplicates App Storage)
+			// External SD cards only (skip internal storage which duplicates App Storage).
+			// Compared by canonical path: the literal "/storage/emulated/0" missed secondary users
+			// and work profiles (/storage/emulated/10), so the primary volume was listed twice and
+			// a "move" between the two identical folders deleted the packs.
+			val known = uniPackWorkspaces.map { canonicalOrAbsolute(it.file) }.toMutableSet()
 			val dirs = context.getExternalFilesDirs("UniPack")
 			var externalIndex = 1
 
 			dirs.filterNotNull().forEach { file ->
+				val canonical = canonicalOrAbsolute(file)
+				if (!known.add(canonical)) return@forEach
 				if (file.absolutePath.contains("/storage/emulated/0")) return@forEach
 
 				val name = context.getString(R.string.workspace_external_sd_card_format, externalIndex)
@@ -241,14 +248,27 @@ class WorkspaceManager(val context: Context) : KoinComponent {
 				files?.forEach {
 					if (!it.isDirectory) return@forEach
 
-					val unipack = UniPackFolder(it).load()
-					val unipackENT = repo.getOrCreate(unipack.id)
+					// One unreadable folder (SD card removed mid-scan, a permission-less directory)
+					// used to abort the whole list and take the activity down with it.
+					try {
+						val unipack = UniPackFolder(it).load()
+						val unipackENT = repo.getOrCreate(unipack.id)
 
-					val packItem = UniPackItem(unipack, unipackENT)
-					unipacks.add(packItem)
+						val packItem = UniPackItem(unipack, unipackENT)
+						unipacks.add(packItem)
+					} catch (e: Exception) {
+						Log.err("getUnipacks: skipping ${it.path}", e)
+					}
 				}
 			}
 
 			unipacks.toList()
+		}
+
+	private fun canonicalOrAbsolute(file: File): String =
+		try {
+			file.canonicalPath
+		} catch (e: java.io.IOException) {
+			file.absolutePath
 		}
 }

--- a/app/src/main/java/com/kimjisub/launchpad/tool/SafMigrationHelper.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/tool/SafMigrationHelper.kt
@@ -8,6 +8,15 @@ import kotlinx.coroutines.withContext
 import net.lingala.zip4j.ZipFile
 import java.io.File
 
+/**
+ * Moves or copies packs between the app folder and a SAF tree.
+ *
+ * Two rules the transfer methods follow, both learned from lost packs:
+ * - a name collision is a *skip*: nothing was written, so the source is never deleted, even in
+ *   move mode (it used to be, and a stale copy at the destination was all that survived);
+ * - a copy that throws half-way removes the partial destination before the error is recorded,
+ *   otherwise the next attempt sees "exists" and skips the pack forever.
+ */
 class SafMigrationHelper(
 	private val context: Context,
 ) {
@@ -49,9 +58,13 @@ class SafMigrationHelper(
 				val dest = File(targetDir, name)
 				if (dest.exists()) {
 					skipped++
-					if (deleteSource) folder.delete()
 				} else {
-					FileManager.copyDocumentTreeToFile(context, folder, dest)
+					try {
+						FileManager.copyDocumentTreeToFile(context, folder, dest)
+					} catch (e: Exception) {
+						FileManager.deleteDirectory(dest)
+						throw e
+					}
 					transferred++
 					if (deleteSource) folder.delete()
 				}
@@ -85,9 +98,15 @@ class SafMigrationHelper(
 				val existing = targetTreeDoc.findFile(folder.name)
 				if (existing != null && existing.isDirectory) {
 					skipped++
-					if (deleteSource) folder.deleteRecursively()
 				} else {
-					FileManager.copyFileToDocumentTree(context, folder, targetTreeDoc)
+					try {
+						FileManager.copyFileToDocumentTree(context, folder, targetTreeDoc)
+					} catch (e: Exception) {
+						// The directory did not exist before this attempt, so removing it only drops
+						// the partial copy.
+						runCatching { targetTreeDoc.findFile(folder.name)?.takeIf { it.isDirectory }?.delete() }
+						throw e
+					}
 					transferred++
 					if (deleteSource) folder.deleteRecursively()
 				}
@@ -123,15 +142,21 @@ class SafMigrationHelper(
 				val existing = targetTreeDoc.findFile(zipName)
 				if (existing != null) {
 					skipped++
-					if (deleteSource) folder.deleteRecursively()
 				} else {
-					val tempZip = File(cacheDir, zipName)
+					// A unique temp name: zip4j *appends* to an existing archive, so a leftover from a
+					// crashed run produced a backup with two copies of every entry.
+					val tempZip = File.createTempFile("transfer-", ".zip", cacheDir).also { it.delete() }
 					try {
 						ZipFile(tempZip).addFolder(folder)
 						val newDoc = targetTreeDoc.createFile("application/zip", zipName)
 						if (newDoc != null) {
-							context.contentResolver.openOutputStream(newDoc.uri)?.use { out ->
-								tempZip.inputStream().use { it.copyTo(out) }
+							try {
+								context.contentResolver.openOutputStream(newDoc.uri)?.use { out ->
+									tempZip.inputStream().use { it.copyTo(out) }
+								} ?: throw java.io.IOException("openOutputStream returned null")
+							} catch (e: Exception) {
+								runCatching { newDoc.delete() }
+								throw e
 							}
 							transferred++
 							if (deleteSource) folder.deleteRecursively()
@@ -181,14 +206,18 @@ class SafMigrationHelper(
 				val dest = File(targetDir, folderName)
 				if (dest.exists()) {
 					skipped++
-					if (deleteSource) doc.delete()
 				} else {
-					val tempZip = File(cacheDir, zipName)
+					val tempZip = File.createTempFile("transfer-", ".zip", cacheDir)
 					try {
 						context.contentResolver.openInputStream(doc.uri)?.use { input ->
 							tempZip.outputStream().use { input.copyTo(it) }
+						} ?: throw java.io.IOException("openInputStream returned null")
+						try {
+							ZipFile(tempZip).extractAll(dest.absolutePath)
+						} catch (e: Exception) {
+							FileManager.deleteDirectory(dest)
+							throw e
 						}
-						ZipFile(tempZip).extractAll(dest.absolutePath)
 						transferred++
 						if (deleteSource) doc.delete()
 					} finally {
@@ -227,9 +256,13 @@ class SafMigrationHelper(
 				val dest = File(targetDir, folder.name)
 				if (dest.exists()) {
 					skipped++
-					if (deleteSource) folder.deleteRecursively()
 				} else {
-					FileManager.copyDirectory(folder, dest)
+					try {
+						FileManager.copyDirectory(folder, dest)
+					} catch (e: Exception) {
+						FileManager.deleteDirectory(dest)
+						throw e
+					}
 					transferred++
 					if (deleteSource) folder.deleteRecursively()
 				}

--- a/app/src/main/java/com/kimjisub/launchpad/tool/UniPackDownloader.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/tool/UniPackDownloader.kt
@@ -14,6 +14,7 @@ import com.kimjisub.launchpad.manager.NotificationManager
 import com.kimjisub.launchpad.unipack.UniPack
 import com.kimjisub.launchpad.unipack.UniPackFolder
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -84,10 +85,16 @@ class UniPackDownloader(
 				withContext(Dispatchers.Main) { onInstallStart() }
 
 				val call = FileApi.service.download(url)
-				val responseBody = call.execute().body()
-				?: throw IOException("Empty response body")
+				val response = call.execute()
+				val responseBody = response.body()
+				?: throw IOException("Empty response body (HTTP ${response.code()})")
+				if (!response.isSuccessful) {
+					responseBody.close()
+					throw IOException("HTTP ${response.code()}")
+				}
 				val contentLength = responseBody.contentLength()
-				val fileSize = contentLength.coerceAtLeast(preKnownFileSize)
+				// -1 (chunked) or 0 with no pre-known size gave Infinity% below
+				val fileSize = contentLength.coerceAtLeast(preKnownFileSize).coerceAtLeast(0L)
 				withContext(Dispatchers.Main) {
 					onGetFileSize(
 						fileSize,
@@ -96,67 +103,77 @@ class UniPackDownloader(
 					)
 				}
 
-				contentResolver.openFileDescriptor(unipackFile.toUri(), "w")?.use {
-					FileOutputStream(it.fileDescriptor).use { outputStream ->
-						responseBody.byteStream().use { inputStream ->
-							val buf = ByteArray(DOWNLOAD_BUFFER_SIZE)
-							var downloadedSize = 0L
-							var n: Int
-							var prevPercent = -1
-							var prevMillis = SystemClock.elapsedRealtime()
-							while (true) {
-								n = inputStream.read(buf)
-								if (n == -1)
-									break
+				// responseBody.use: a failed openFileDescriptor used to skip the whole block silently
+				// and leak the HTTP body; now it throws and the body is always closed.
+				responseBody.use { body ->
+					val pfd = contentResolver.openFileDescriptor(unipackFile.toUri(), "w")
+						?: throw IOException("Could not open ${unipackFile.path} for writing")
+					pfd.use {
+						FileOutputStream(it.fileDescriptor).use { outputStream ->
+							body.byteStream().use { inputStream ->
+								val buf = ByteArray(DOWNLOAD_BUFFER_SIZE)
+								var downloadedSize = 0L
+								var n: Int
+								var prevPercent = -1
+								var prevMillis = SystemClock.elapsedRealtime()
+								while (true) {
+									n = inputStream.read(buf)
+									if (n == -1)
+										break
 
-								outputStream.write(buf, 0, n)
-								downloadedSize += n.toLong()
-								val millis = SystemClock.elapsedRealtime()
-								if (millis - prevMillis > PROGRESS_UPDATE_INTERVAL_MS) {
-									val percent = (downloadedSize.toFloat() / fileSize * PERCENT_MULTIPLIER).toInt()
-									withContext(Dispatchers.Main) {
-										onDownloadProgress(
-											percent,
-											downloadedSize,
-											fileSize
-										)
-									}
-									prevMillis = millis
-
-									if (prevPercent != percent) {
+									outputStream.write(buf, 0, n)
+									downloadedSize += n.toLong()
+									val millis = SystemClock.elapsedRealtime()
+									if (millis - prevMillis > PROGRESS_UPDATE_INTERVAL_MS) {
+										val percent = if (fileSize > 0) (downloadedSize.toFloat() / fileSize * PERCENT_MULTIPLIER).toInt() else -1
 										withContext(Dispatchers.Main) {
-											onDownloadProgressPercent(
+											onDownloadProgress(
 												percent,
 												downloadedSize,
 												fileSize
 											)
 										}
-										prevPercent = percent
+										prevMillis = millis
+
+										if (prevPercent != percent) {
+											withContext(Dispatchers.Main) {
+												onDownloadProgressPercent(
+													percent,
+													downloadedSize,
+													fileSize
+												)
+											}
+											prevPercent = percent
+										}
 									}
 								}
 							}
 						}
-
-						withContext(Dispatchers.Main) { onImportStart(unipackFile) }
-
-						ZipFile(unipackFile).use { zip ->
-							zip.extractAll(folder.path)
-						}
-						FileManager.removeDoubleFolder(folder.path)
-						val unipack = UniPackFolder(folder).loadDetail()
-						if (unipack.criticalError) {
-							val errorMsg = unipack.errorDetail ?: "Unknown error"
-							Log.err(errorMsg)
-							FileManager.deleteDirectory(folder)
-							throw UniPackCriticalErrorException(errorMsg)
-						}
-
-						withContext(Dispatchers.Main) { onInstallComplete(folder, unipack) }
-
 					}
 				}
 
+				withContext(Dispatchers.Main) { onImportStart(unipackFile) }
 
+				ZipFile(unipackFile).use { zip ->
+					zip.extractAll(folder.path)
+				}
+				FileManager.removeDoubleFolder(folder.path)
+				val unipack = UniPackFolder(folder).loadDetail()
+				if (unipack.criticalError) {
+					val errorMsg = unipack.errorDetail ?: "Unknown error"
+					Log.err(errorMsg)
+					FileManager.deleteDirectory(folder)
+					throw UniPackCriticalErrorException(errorMsg)
+				}
+
+				withContext(Dispatchers.Main) { onInstallComplete(folder, unipack) }
+
+			} catch (e: CancellationException) {
+				// The hosting scope was cancelled (activity destroyed): remove the half-written
+				// folder, but do not report it as a failure and do not swallow the cancellation.
+				FileManager.deleteDirectory(folder)
+				FileManager.deleteDirectory(unipackFile)
+				throw e
 			} catch (e: Exception) {
 				Log.err("Download failed", e)
 				withContext(Dispatchers.Main) { onException(e) }


### PR DESCRIPTION
## What

Fixes the data-loss blockers (and the downloader/notification/store majors) from the whole-repo review of the Android app layer. Full notes live in the private workspace repo under `design/2026-09-07/reviews/android-app-layer.md`.

### Data loss
- `SafMigrationHelper`: a name collision is a skip and never deletes the source. In move mode the good copy was deleted and only the stale destination survived. A copy that throws half-way removes the partial destination, so the next attempt does not see "exists" and skip the pack forever. The temp ZIP has a unique name (zip4j appends to an existing archive). A failed SAF write deletes the partial document.
- `FileManager.copyFileToDocumentTree`: the mime type comes from the real extension and the full name is passed, so `clip.m4a` and `theme.json` keep their extensions in a folder backup. `nameWithoutExtension` plus `application/octet-stream` dropped them and `keySound` could not find the sounds afterwards. A failed create/open throws instead of returning silently.
- `WorkspaceManager`: workspaces are de-duplicated by canonical path. The literal `/storage/emulated/0` check listed the primary volume twice on secondary users and work profiles, and a move between the two identical folders deleted the packs. `getUnipacks` skips an unreadable folder instead of aborting the whole list.
- proguard: `-keep class com.kimjisub.launchpad.api.**.vo.** { *; }`. R8 renamed `UnishareVO`'s fields, so every `unipad://` import in a release build downloaded `.../unishare/null/download`. Verified in the release mapping: the class and its fields are kept.

### Downloader
- A null `openFileDescriptor` throws (it used to skip the whole download silently and leak the HTTP body); the body is always closed; a non-2xx response fails early; `CancellationException` is not reported as a failure and the half-written folder is removed; an unknown `Content-Length` no longer yields an Infinity percentage.

### Other
- `POST_NOTIFICATIONS` declared and requested once on Android 13+ from the splash. Download/import notifications were dropped silently. Whatever the answer, the app proceeds. The splash also resumes its timer after being backgrounded instead of staying forever.
- `FBStoreActivity`: `LazyColumn` keyed by the Firebase child key (two entries sharing a `code`, or two null codes, crashed the list).
- `PlayActivity`: guide animation callbacks guard `padViews`; the MIDI controller is only registered from `initLayout` while resumed.
- `BaseActivity.restartApp` uses `Intent.makeRestartActivityTask` + exit; the plain start followed by `killProcess` left a dead task and no app.

## Verification

| Check | Result |
|---|---|
| `:app:compileDebugKotlin` | ok |
| `:app:testDebugUnitTest` | 279 / 279 |
| `:app:lintDebug` | 0 errors |
| `:app:bundleRelease` (R8) | ok, 27.8 MB; `UnishareVO` unobfuscated in `mapping.txt` |

Behaviour change to note: on Android 13+ the first launch now asks for notification permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)