### PR TITLE
fix(app): main-thread I/O, theme decoding, store list race, shared HTTP client

### DIFF
--- a/app/src/main/java/com/kimjisub/launchpad/activity/FBStoreActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/FBStoreActivity.kt
@@ -72,6 +72,7 @@ import com.kimjisub.launchpad.ui.theme.UniPadTheme
 import com.kimjisub.launchpad.unipack.UniPack
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import com.google.android.material.snackbar.Snackbar
 import java.io.File
 import java.text.NumberFormat
@@ -104,7 +105,14 @@ class FBStoreActivity : BaseActivity() {
 		super.onCreate(savedInstanceState)
 
 		lifecycleScope.launch(Dispatchers.IO) {
-			downloadList = ws.getUnipacks()
+			val list = ws.getUnipacks()
+			// Store entries that arrived before this finished were flagged "not downloaded" for good.
+			withContext(Dispatchers.Main) {
+				downloadList = list
+				for (item in storeItems) {
+					item.downloaded = list.any { it.unipack.id == item.storeVO.code }
+				}
+			}
 		}
 
 		setContent {

--- a/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
@@ -173,6 +173,8 @@ class PlayActivity : BaseActivity() {
 
 	private val audioManager: AudioManager by lazy { getSystemService(AUDIO_SERVICE) as AudioManager }
 
+	// Registered on the whole Settings.System tree: it fires for brightness, rotation, font scale...
+	// so only volume keys (or an unknown uri) refresh the UI.
 	private val volumeObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
 		override fun onChange(selfChange: Boolean) {
 			log("changed volume 1")
@@ -181,8 +183,11 @@ class PlayActivity : BaseActivity() {
 		}
 
 		override fun onChange(selfChange: Boolean, uri: Uri?) {
-			log("changed volume 2")
-			updateVolumeUI()
+			val key = uri?.lastPathSegment
+			if (key == null || key.contains("volume")) {
+				log("changed volume 2")
+				updateVolumeUI()
+			}
 			super.onChange(selfChange, uri)
 		}
 	}
@@ -325,7 +330,8 @@ class PlayActivity : BaseActivity() {
 
 		// Load theme and unipack asynchronously after first frame
 		lifecycleScope.launch {
-			// Load theme on main thread (needs resource access) after first frame is drawn
+			// Disk reads and up to ten BitmapFactory.decodeFile calls: off the main thread, with the
+			// Snackbar/dialog fallbacks still applied on main.
 			initTheme()
 
 			try {
@@ -365,10 +371,10 @@ class PlayActivity : BaseActivity() {
 		vm.startReady = theme != null
 	}
 
-	private fun initTheme() {
+	private suspend fun initTheme() {
 		val themeId = p.selectedTheme
 		theme = try {
-			loadTheme(this@PlayActivity, themeId, true)
+			withContext(Dispatchers.IO) { loadTheme(this@PlayActivity, themeId, true) }
 		} catch (e: OutOfMemoryError) {
 			Log.err("Theme OOM: $themeId", e)
 			Snackbar.make(findViewById(android.R.id.content), "${getString(string.skinMemoryErr)}\n$themeId", Snackbar.LENGTH_SHORT).show()

--- a/app/src/main/java/com/kimjisub/launchpad/activity/ThemeActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/ThemeActivity.kt
@@ -82,6 +82,9 @@ import com.kimjisub.launchpad.manager.loadTheme
 import com.kimjisub.launchpad.tool.ZipThemeImporter
 import com.kimjisub.launchpad.tool.splitties.browse
 import com.kimjisub.launchpad.ui.theme.Orange
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
+import com.kimjisub.launchpad.tool.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -91,8 +94,15 @@ class ThemeActivity : BaseActivity() {
 		super.onCreate(savedInstanceState)
 
 		setContent {
-			var themes by remember { mutableStateOf(ThemeTool.getThemePackList(applicationContext)) }
+			// getThemePackList enumerates assets and external storage and decodes every icon; it
+			// ran inside composition on the main thread.
+			var themes by remember { mutableStateOf<List<ThemeItem>>(emptyList()) }
 			var appliedIndex by remember(themes) { mutableIntStateOf(getSavedTheme(themes)) }
+			val scope = rememberCoroutineScope()
+			suspend fun reloadThemes() {
+				themes = withContext(Dispatchers.IO) { ThemeTool.getThemePackList(applicationContext) }
+			}
+			LaunchedEffect(Unit) { reloadThemes() }
 
 			ThemeScreen(
 				themes = themes,
@@ -108,14 +118,17 @@ class ThemeActivity : BaseActivity() {
 					browse("https://github.com/kimjisub/unipad-android/blob/main/docs/THEME_CREATION_GUIDE.md")
 				},
 				onImport = { uri ->
-					try {
-						ZipThemeImporter.import(this, uri)
-						themes = ThemeTool.getThemePackList(applicationContext)
-						Toast.makeText(this, getString(R.string.theme_import_success), Toast.LENGTH_SHORT).show()
-					} catch (e: ZipThemeImporter.InvalidThemeException) {
-						Toast.makeText(this, "${getString(R.string.theme_import_invalid)}\n${e.message}", Toast.LENGTH_SHORT).show()
-					} catch (e: Exception) {
-						Toast.makeText(this, "${getString(R.string.theme_import_failed)}\n${e.message}", Toast.LENGTH_SHORT).show()
+					// Copying and extracting the ZIP used to run inside the click handler on main.
+					scope.launch {
+						try {
+							withContext(Dispatchers.IO) { ZipThemeImporter.import(this@ThemeActivity, uri) }
+							reloadThemes()
+							Toast.makeText(this@ThemeActivity, getString(R.string.theme_import_success), Toast.LENGTH_SHORT).show()
+						} catch (e: ZipThemeImporter.InvalidThemeException) {
+							Toast.makeText(this@ThemeActivity, "${getString(R.string.theme_import_invalid)}\n${e.message}", Toast.LENGTH_SHORT).show()
+						} catch (e: Exception) {
+							Toast.makeText(this@ThemeActivity, "${getString(R.string.theme_import_failed)}\n${e.message}", Toast.LENGTH_SHORT).show()
+						}
 					}
 				},
 				onDelete = { themeItem ->
@@ -124,7 +137,7 @@ class ThemeActivity : BaseActivity() {
 						if (p.selectedTheme == themeItem.id) {
 							p.selectedTheme = packageName
 						}
-						themes = ThemeTool.getThemePackList(applicationContext)
+						scope.launch { reloadThemes() }
 					}
 				},
 			)
@@ -194,6 +207,11 @@ private fun ThemeScreen(
 						customLogo = res.customLogo?.toBitmap()?.asImageBitmap(),
 					)
 				} catch (_: OutOfMemoryError) {
+					null
+				} catch (e: Exception) {
+					// A theme whose theme.json was removed under us throws IllegalArgumentException;
+					// only OOM was caught and the activity crashed.
+					Log.err("theme preview failed: $themeId", e)
 					null
 				}
 			}

--- a/app/src/main/java/com/kimjisub/launchpad/adapter/ThemeAdapter.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/adapter/ThemeAdapter.kt
@@ -58,13 +58,28 @@ class ThemeItem private constructor(
 			val themeJsonFile = File(dir, "theme.json")
 			val metadata = json.decodeFromString<ZipThemeMetadata>(themeJsonFile.readText())
 			val iconFile = File(dir, "theme_ic.png")
-			val icon: Drawable = if (iconFile.exists()) {
-				val bitmap = BitmapFactory.decodeFile(iconFile.absolutePath)
-				BitmapDrawable(context.resources, bitmap)
-			} else {
-				requireNotNull(ResourcesCompat.getDrawable(context.resources, R.drawable.theme_ic, null))
-			}
+			val icon: Drawable = decodeIconBounded(iconFile)?.let { BitmapDrawable(context.resources, it) }
+				?: requireNotNull(ResourcesCompat.getDrawable(context.resources, R.drawable.theme_ic, null))
 			return ThemeItem("zip://${dir.name}", icon, metadata.name, metadata.author, metadata.version, ThemeType.ZIP, isBundled)
+		}
+
+		private const val MAX_ICON_EDGE = 512
+
+		/** A user theme icon is arbitrary; a 4000x4000 PNG decoded at full size threw OOM out of composition. */
+		private fun decodeIconBounded(file: File): android.graphics.Bitmap? {
+			if (!file.exists()) return null
+			val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+			BitmapFactory.decodeFile(file.absolutePath, bounds)
+			if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+			var sample = 1
+			while (bounds.outWidth / sample > MAX_ICON_EDGE || bounds.outHeight / sample > MAX_ICON_EDGE) sample *= 2
+			val opts = BitmapFactory.Options().apply { inSampleSize = sample }
+			return try {
+				BitmapFactory.decodeFile(file.absolutePath, opts)
+			} catch (e: OutOfMemoryError) {
+				Log.err("theme icon too large: ${file.path}", e)
+				null
+			}
 		}
 	}
 }

--- a/app/src/main/java/com/kimjisub/launchpad/api/BaseApiService.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/api/BaseApiService.kt
@@ -90,15 +90,25 @@ object BaseApiService {
 			}).create()
 	}
 
-	fun <T> createRetrofitService(baseUrl: String, serviceClass: Class<T>): T {
+	// One client for every service: each Retrofit service used to build its own connection pool,
+	// dispatcher, and thread pools. No callTimeout on purpose (a pack download may take minutes);
+	// connect/read timeouts stop a stalled socket from holding a download forever.
+	private val sharedClient: OkHttpClient by lazy {
 		val httpLoggingInterceptor = HttpLoggingInterceptor { message -> Log.network(message) }
 		// Never BODY: the same client downloads UniPack ZIPs, and BODY buffers the whole
 		// response in memory before logging it (Crashlytics b1f34473 / 0a626898: OOM in
 		// okio.Segment during UniPackDownloader).
 		httpLoggingInterceptor.level = Level.HEADERS
-		val client = okHttpClientBuilder
+		okHttpClientBuilder
+			.connectTimeout(20, java.util.concurrent.TimeUnit.SECONDS)
+			.readTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+			.writeTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
 			.addInterceptor(httpLoggingInterceptor)
 			.build()
+	}
+
+	fun <T> createRetrofitService(baseUrl: String, serviceClass: Class<T>): T {
+		val client = sharedClient
 		return Retrofit.Builder()
 			.baseUrl(baseUrl)
 			.addConverterFactory(GsonConverterFactory.create(gson))


### PR DESCRIPTION
## What

Major-tier findings from the 2026-09-07 app-layer review (`design/2026-09-07/reviews/android-app-layer.md` in the private workspace repo).

- `PlayActivity.initTheme` runs `loadTheme` on `Dispatchers.IO`. Disk reads and up to ten `BitmapFactory.decodeFile` calls ran on the main thread after the first frame. The Snackbar/dialog fallbacks stay on main.
- The volume `ContentObserver` is registered on the whole `Settings.System` tree and refreshed on every system-setting write (brightness, rotation, font scale). It now refreshes only for volume keys.
- `ThemeAdapter.fromZipDir` decodes the icon with `inJustDecodeBounds` + `inSampleSize` (edge <= 512). A large user icon threw `OutOfMemoryError` out of composition.
- `ThemeActivity`: the theme list, the ZIP import, and the reload after delete run on `Dispatchers.IO` from a coroutine instead of inside composition and click handlers. The preview `LaunchedEffect` catches every failure, not only OOM.
- `FBStoreActivity`: entries that arrived before `getUnipacks()` finished were flagged "not downloaded" for good. The flag is recomputed once the list is in.
- `BaseApiService`: one shared `OkHttpClient` for every Retrofit service, with connect 20 s / read 60 s / write 60 s timeouts and no `callTimeout`, so a stalled socket ends but a long pack download does not.

## Verification

| Check | Result |
|---|---|
| `:app:compileDebugKotlin` | ok |
| `:app:testDebugUnitTest` | 279 / 279 |
| `:app:lintDebug` | 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)