### PR TITLE
fix(parity): align parser, import, store, and play screen with iOS/web where Android had drifted

### DIFF
--- a/app/src/main/java/com/kimjisub/launchpad/activity/FBStoreActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/FBStoreActivity.kt
@@ -150,10 +150,14 @@ class FBStoreActivity : BaseActivity() {
 					onYoutubeClick = {
 						val item = storeItems.firstOrNull { it.isToggle }
 						if (item != null) {
-							browse("https://www.youtube.com/results?search_query=UniPad+${item.storeVO.title}+${item.storeVO.producerName}")
+							browse("https://www.youtube.com/results?search_query=" + android.net.Uri.encode("UniPad ${item.storeVO.title} ${item.storeVO.producerName}"))
 						}
 					},
-					onWebsiteClick = {},
+					onWebsiteClick = {
+						// The icon was rendered with an empty handler; iOS/web open the entry's URL.
+						val url = storeItems.firstOrNull { it.isToggle }?.storeVO?.URL
+						if (url != null && url.startsWith("http")) browse(url)
+					},
 				)
 			}
 		}
@@ -218,7 +222,8 @@ class FBStoreActivity : BaseActivity() {
 		UniPackDownloader(
 			context = this,
 			title = item.storeVO.title ?: "",
-			url = "$DOWNLOAD_BASE_URL?code=$itemCode",
+			// iOS/web prefer the entry's own URL and only fall back to the legacy Cloud Function.
+			url = item.storeVO.URL?.takeIf { it.startsWith("http") } ?: "$DOWNLOAD_BASE_URL?code=${android.net.Uri.encode(itemCode)}",
 			workspace = ws.downloadWorkspace.file,
 			folderName = item.storeVO.code ?: "",
 			listener = object : UniPackDownloader.Listener {

--- a/app/src/main/java/com/kimjisub/launchpad/activity/MainActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/MainActivity.kt
@@ -212,7 +212,8 @@ class MainActivity : BaseActivity() {
 							Intent(applicationContext, FBStoreActivity::class.java)
 						)
 					},
-					onLoadUniPackClick = { filePick.launch(arrayOf("*/*")) },
+					// Same filter as iOS (.zip); picking an MP3 used to fail deep inside zip4j.
+					onLoadUniPackClick = { filePick.launch(arrayOf("application/zip", "application/x-zip-compressed", "application/octet-stream")) },
 					onRestoreClick = {
 						settingsActivityResultLauncher.launch(
 							Intent(applicationContext, SettingsActivity::class.java).apply {
@@ -388,6 +389,8 @@ class MainActivity : BaseActivity() {
 
 						else -> {
 							importResult = ImportResult.Warning(unipack.errorDetail.orEmpty())
+							// The pack was kept; without this it only appeared on the next resume.
+							update()
 						}
 					}
 				}

--- a/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/PlayActivity.kt
@@ -480,7 +480,9 @@ class PlayActivity : BaseActivity() {
 					)
 				}
 			}
-			theme?.customLogo?.let { logo ->
+			// "Hide UI" (optionViewVisible) was written by the view model and read nowhere: the
+			// switch only changed launchpad LEDs. It hides the logo and the chrome column, as web does.
+			if (vm.optionViewVisible) theme?.customLogo?.let { logo ->
 				val bitmap = remember(logo) { logo.toBitmap().asImageBitmap() }
 				Image(
 					bitmap = bitmap,
@@ -545,7 +547,7 @@ class PlayActivity : BaseActivity() {
 								} },
 								modifier = Modifier.wrapContentSize()
 							)
-							if (!vm.isOptionWindowVisible) {
+							if (!vm.isOptionWindowVisible && vm.optionViewVisible) {
 								ChromeColumn()
 							} else {
 								Spacer(modifier = Modifier.size(0.dp))
@@ -676,8 +678,9 @@ class PlayActivity : BaseActivity() {
 
 	@Composable
 	private fun OptionPanel() {
-		val panelBg = PlayPalette.panelBackground
-		val accentColor = PlayPalette.accent
+		// Theme colours (colors.json option_window / option_window_checkbox), as iOS and web apply them.
+		val panelBg = theme?.optionWindow?.let { Color(it).copy(alpha = 0.94f) } ?: PlayPalette.panelBackground
+		val accentColor = theme?.optionWindowCheckbox?.let { Color(it) } ?: PlayPalette.accent
 		val textColor = Color.White
 		val sectionColor = textColor.copy(alpha = 0.65f)
 		var infoExpanded by remember { mutableStateOf(false) }
@@ -1066,7 +1069,8 @@ class PlayActivity : BaseActivity() {
 		if (item != null) {
 			when (item.channel) {
 				Channel.GUIDE -> pad.setLedBackgroundColor(item.color)
-				Channel.PRESSED -> pad.setLedBackground(theme?.btnPressed)
+				// A theme without btn_ used to show no press feedback at all; iOS/web fall back to the colour.
+				Channel.PRESSED -> theme?.btnPressed?.let { pad.setLedBackground(it) } ?: pad.setLedBackgroundColor(item.color)
 				Channel.LED -> pad.setLedBackgroundColor(item.color)
 				else -> {}
 			}

--- a/app/src/main/java/com/kimjisub/launchpad/manager/ChannelManager.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/manager/ChannelManager.kt
@@ -63,7 +63,8 @@ class ChannelManager(x: Int, y: Int) {
 	}
 
 	fun add(x: Int, y: Int, channel: Channel, color: Int, code: Int) {
-		val resolvedColor = if (color == NO_COLOR) LaunchpadColor.ARGB[code].toInt() else color
+		// A pack LED code outside the 128-entry palette threw here; iOS/web resolve it to 0.
+		val resolvedColor = if (color == NO_COLOR) LaunchpadColor.ARGB.getOrNull(code)?.toInt() ?: 0 else color
 		if (x != -1)
 			btn[x][y][channel.priority] = Item(channel, resolvedColor, code)
 		else

--- a/app/src/main/java/com/kimjisub/launchpad/manager/FileManager.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/manager/FileManager.kt
@@ -17,6 +17,7 @@ object FileManager {
 	private const val COPY_BUFFER_SIZE = 4096
 	private const val BYTES_PER_MB = 1024 * 1024
 	private const val DEFAULT_DURATION_MS = 10000
+	private const val MAX_UNWRAP_DEPTH = 8
 	private val FILENAME_FILTER_REGEX = "[|\\\\?*<\":>/]+".toRegex()
 
 	fun removeDoubleFolder(path: String) {
@@ -24,11 +25,17 @@ object FileManager {
 			val rootFolder = File(path)
 			if (!rootFolder.isDirectory) return
 
-			val children = rootFolder.listFiles() ?: return
-			val nonHidden = children.filter { !it.name.startsWith(".") }
-
-			if (nonHidden.size == 1 && nonHidden[0].isDirectory) {
-				moveDirectory(nonHidden[0], rootFolder)
+			// Repeats like iOS (Pack/Pack/Pack/info used to stay broken here), and Finder's
+			// __MACOSX sibling does not count as content (every Mac-zipped pack was rejected).
+			repeat(MAX_UNWRAP_DEPTH) {
+				val children = rootFolder.listFiles() ?: return
+				val nonHidden = children.filter { !it.name.startsWith(".") && it.name != "__MACOSX" }
+				if (nonHidden.size == 1 && nonHidden[0].isDirectory) {
+					children.filter { it.name == "__MACOSX" }.forEach { deleteDirectory(it) }
+					moveDirectory(nonHidden[0], rootFolder)
+				} else {
+					return
+				}
 			}
 		} catch (e: IOException) {
 			Log.err("removeDoubleFolder failed", e)

--- a/app/src/main/java/com/kimjisub/launchpad/manager/WorkspaceManager.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/manager/WorkspaceManager.kt
@@ -77,6 +77,9 @@ class WorkspaceManager(val context: Context) : KoinComponent {
 				val name = context.getString(R.string.workspace_external_sd_card_format, externalIndex)
 				externalIndex++
 
+				// App Storage gets one; the SD workspaces did not, so their samples showed up in the
+				// gallery and music apps.
+				FileManager.makeNomedia(file)
 				uniPackWorkspaces.add(
 					Workspace(name, file)
 				)

--- a/app/src/main/java/com/kimjisub/launchpad/manager/ZipThemeResources.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/manager/ZipThemeResources.kt
@@ -82,9 +82,22 @@ class ZipThemeResources(
 		}
 	}
 
+	// iOS and web accept these alternate stems and .webp/.jpg; a theme authored against them lost
+	// images here.
+	private val nameAliases = mapOf(
+		"playbg" to listOf("play_bg"),
+		"custom_logo" to listOf("customlogo", "custom-logo", "logo"),
+		"btn_" to listOf("btn_pressed", "btn-pressed"),
+		"chain_" to listOf("chain_selected"),
+		"chain__" to listOf("chain_guide"),
+		"phantom_" to listOf("phantom_variant"),
+	)
+	private val imageExtensions = listOf("png", "webp", "jpg", "jpeg")
+
 	private fun loadPng(name: String): Drawable? {
-		val file = File(themeDir, "$name.png")
-		if (!file.exists()) return null
+		val stems = listOf(name) + (nameAliases[name] ?: emptyList())
+		val file = stems.flatMap { stem -> imageExtensions.map { File(themeDir, "$stem.$it") } }.firstOrNull { it.exists() }
+			?: return null
 		val bitmap = BitmapFactory.decodeFile(file.absolutePath) ?: return null
 		return BitmapDrawable(context.resources, bitmap)
 	}

--- a/app/src/main/java/com/kimjisub/launchpad/midi/driver/DriverRef.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/driver/DriverRef.kt
@@ -83,7 +83,9 @@ abstract class DriverRef {
 	}
 
 	internal fun sendSignal(cmd: Int, sig: Int, note: Int, velocity: Int) {
-		sendSignal(cmd.toByte(), sig.toByte(), note.toByte(), velocity.toByte())
+		// note/velocity are MIDI data bytes: a pack LED code of 200 went out as 0xC8, a status byte
+		// in a data position (web clamps the same way).
+		sendSignal(cmd.toByte(), sig.toByte(), note.coerceIn(0, 127).toByte(), velocity.coerceIn(0, 127).toByte())
 	}
 
 	internal fun sendRawSignal(bytes: ByteArray, cableNumber: Int = 0) {

--- a/app/src/main/java/com/kimjisub/launchpad/tool/UniPackDownloader.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/tool/UniPackDownloader.kt
@@ -158,7 +158,9 @@ class UniPackDownloader(
 					zip.extractAll(folder.path)
 				}
 				FileManager.removeDoubleFolder(folder.path)
-				val unipack = UniPackFolder(folder).loadDetail()
+				// load() runs checkFile + info; without it every parser returned early and criticalError
+				// was always false, so any archive installed as a pack.
+				val unipack = UniPackFolder(folder).load().loadDetail()
 				if (unipack.criticalError) {
 					val errorMsg = unipack.errorDetail ?: "Unknown error"
 					Log.err(errorMsg)

--- a/app/src/main/java/com/kimjisub/launchpad/tool/ZipThemeImporter.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/tool/ZipThemeImporter.kt
@@ -40,14 +40,11 @@ object ZipThemeImporter {
 				tempZip.delete()
 			}
 
-			// Validate: theme.json and theme_ic.png must exist
+			// Validate: theme.json must exist. The icon is optional (the list falls back to the
+			// default icon), as on iOS and web.
 			val themeJson = File(targetDir, "theme.json")
-			val themeIcon = File(targetDir, "theme_ic.png")
 			if (!themeJson.exists()) {
 				throw InvalidThemeException("theme.json not found")
-			}
-			if (!themeIcon.exists()) {
-				throw InvalidThemeException("theme_ic.png not found")
 			}
 
 			return targetDir.name

--- a/app/src/main/java/com/kimjisub/launchpad/unipack/UniPack.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/unipack/UniPack.kt
@@ -123,12 +123,13 @@ abstract class UniPack {
 			val sounds = soundTable?.get(c)?.get(x)?.get(y) ?: return
 			if (sounds.isEmpty()) return
 			val targetNum = num % sounds.size
+			// Bounded like iOS/web: a queue without the target num used to spin forever.
 			if (sounds[0].num != targetNum)
-				while (true) {
+				repeat(sounds.size) {
 					val item = sounds.removeFirst()
 					sounds.addLast(item)
 					if (sounds[0].num == targetNum)
-						break
+						return
 				}
 		} catch (e: IndexOutOfBoundsException) {
 			err("soundPush ($c, $x, $y, $num)")
@@ -164,10 +165,10 @@ abstract class UniPack {
 			if (leds.isEmpty()) return  // Crashlytics 313e518c: divide by zero on an empty cell
 			val targetNum = num % leds.size
 			if (leds[0].num != targetNum)
-				while (true) {
+				repeat(leds.size) {
 					val item = leds.removeFirst()
 					leds.addLast(item)
-					if (leds[0].num == targetNum) break
+					if (leds[0].num == targetNum) return
 				}
 		} catch (e: IndexOutOfBoundsException) {
 			err("ledPush ($c, $x, $y, $num)")

--- a/app/src/main/java/com/kimjisub/launchpad/unipack/UniPackFolder.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/unipack/UniPackFolder.kt
@@ -6,13 +6,55 @@ import com.kimjisub.launchpad.manager.LaunchpadColor.ARGB
 import com.kimjisub.launchpad.unipack.struct.AutoPlay
 import com.kimjisub.launchpad.unipack.struct.LedAnimation
 import com.kimjisub.launchpad.unipack.struct.Sound
+import java.io.BufferedInputStream
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileNotFoundException
+import java.io.InputStream
 import java.io.InputStreamReader
+import java.io.Reader
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+
+/**
+ * Tokeniser shared by the text tables. `\s` in Java regex is ASCII-only, so a line separated by a
+ * no-break space (U+00A0) or an ideographic space (U+3000, Korean IME) was one token and dropped,
+ * while iOS and web split it. The class lists the Unicode space separators explicitly.
+ */
+private val TOKEN_SPLIT = Regex("[\\s\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]+")
+
+/** trim() plus the UTF-8 BOM, which Windows Notepad puts before the first key. */
+private fun String.trimLine(): String = trim { it.isWhitespace() || it == '\uFEFF' }
+
+/**
+ * A reader that honours a BOM: UTF-16 (FE FF / FF FE) as iOS does, UTF-8 with the BOM skipped,
+ * otherwise UTF-8 (Android's platform default). A UTF-16 info used to decode to garbage and reject
+ * the pack here while it played on iOS.
+ */
+private fun bomAwareReader(input: InputStream): Reader {
+	val buffered = BufferedInputStream(input)
+	buffered.mark(3)
+	val b = ByteArray(3)
+	val n = buffered.read(b)
+	val charset: Charset
+	val skip: Int
+	when {
+		n >= 2 && b[0] == 0xFE.toByte() && b[1] == 0xFF.toByte() -> { charset = StandardCharsets.UTF_16BE; skip = 2 }
+		n >= 2 && b[0] == 0xFF.toByte() && b[1] == 0xFE.toByte() -> { charset = StandardCharsets.UTF_16LE; skip = 2 }
+		n >= 3 && b[0] == 0xEF.toByte() && b[1] == 0xBB.toByte() && b[2] == 0xBF.toByte() -> { charset = StandardCharsets.UTF_8; skip = 3 }
+		else -> { charset = StandardCharsets.UTF_8; skip = 0 }
+	}
+	buffered.reset()
+	var toSkip = skip.toLong()
+	while (toSkip > 0) toSkip -= buffered.skip(toSkip)
+	return InputStreamReader(buffered, charset)
+}
 
 class UniPackFolder(val rootFolder: File) : UniPack() {
+	private companion object {
+		const val MAX_GRID_SIZE = 64
+	}
 
 	private var infoFile: File? = null
 	private var soundsDir: File? = null
@@ -101,9 +143,9 @@ class UniPackFolder(val rootFolder: File) : UniPack() {
 			criticalError = true
 			return
 		}
-		BufferedReader(InputStreamReader(inputStream)).use { reader ->
+		BufferedReader(bomAwareReader(inputStream)).use { reader ->
 			while (true) {
-				val s = reader.readLine()?.trim() ?: break
+				val s = reader.readLine()?.trimLine() ?: break
 				if (s.isEmpty()) continue
 				try {
 					val split = s.split("=", limit = 2)
@@ -120,6 +162,10 @@ class UniPackFolder(val rootFolder: File) : UniPack() {
 					}
 				} catch (e: IndexOutOfBoundsException) {
 					addErr("info : [$s] format is not found")
+				} catch (e: NumberFormatException) {
+					// Used to propagate out of load(): the pack vanished from the library with no
+					// message (WorkspaceManager's catch). iOS/web record it and carry on.
+					addErr("info : [$s] format is incorrect")
 				}
 			}
 		}
@@ -130,6 +176,12 @@ class UniPackFolder(val rootFolder: File) : UniPack() {
 		if (chain == 0) addErr("info : chain was missing")
 		if (chain !in 1..24) {
 			addErr("info : chain out of range")
+			criticalError = true
+		}
+		// Same bound as iOS: a negative value threw NegativeArraySizeException in the table
+		// allocation and a huge one allocated chain * x * y cells.
+		if (buttonX !in 0..MAX_GRID_SIZE || buttonY !in 0..MAX_GRID_SIZE) {
+			addErr("info : buttonX/buttonY out of range")
 			criticalError = true
 		}
 	}
@@ -151,11 +203,11 @@ class UniPackFolder(val rootFolder: File) : UniPack() {
 			criticalError = true
 			return
 		}
-		BufferedReader(InputStreamReader(inputStream)).use { reader ->
+		BufferedReader(bomAwareReader(inputStream)).use { reader ->
 			while (true) {
-				val s = reader.readLine()?.trim() ?: break
+				val s = reader.readLine()?.trimLine() ?: break
 				if (s.isEmpty()) continue
-				val split = s.trim().split("\\s+".toRegex()).toTypedArray()
+				val split = s.trim().split(TOKEN_SPLIT).toTypedArray()
 				var c: Int
 				var x: Int
 				var y: Int
@@ -227,7 +279,7 @@ class UniPackFolder(val rootFolder: File) : UniPack() {
 			for (file in fileList) {
 				if (file.isFile) {
 					val fileName: String = file.name.trim()
-					val split1 = fileName.trim().split("\\s+".toRegex()).toTypedArray()
+					val split1 = fileName.trim().split(TOKEN_SPLIT).toTypedArray()
 					var c: Int
 					var x: Int
 					var y: Int
@@ -265,11 +317,11 @@ class UniPackFolder(val rootFolder: File) : UniPack() {
 						addErr("keyLed : [$fileName] file was not found")
 						continue
 					}
-					BufferedReader(InputStreamReader(inputStream)).use { reader ->
+					BufferedReader(bomAwareReader(inputStream)).use { reader ->
 						loop@ while (true) {
-							val s = reader.readLine()?.trim() ?: break
+							val s = reader.readLine()?.trimLine() ?: break
 							if (s.isEmpty()) continue@loop
-							val split2 = s.trim().split("\\s+".toRegex()).toTypedArray()
+							val split2 = s.trim().split(TOKEN_SPLIT).toTypedArray()
 							var option: String
 							var ledX = -1
 							var ledY = -1
@@ -384,11 +436,11 @@ class UniPackFolder(val rootFolder: File) : UniPack() {
 			addErr("autoPlay : file was not found")
 			return
 		}
-		BufferedReader(InputStreamReader(inputStream)).use { reader ->
+		BufferedReader(bomAwareReader(inputStream)).use { reader ->
 			loop@ while (true) {
-				val s = reader.readLine()?.trim() ?: break
+				val s = reader.readLine()?.trimLine() ?: break
 				if (s.isEmpty()) continue@loop
-				val split = s.trim().split("\\s+".toRegex()).toTypedArray()
+				val split = s.trim().split(TOKEN_SPLIT).toTypedArray()
 				var option: String
 				var x = -1
 				var y = -1

--- a/app/src/main/java/com/kimjisub/launchpad/viewmodel/MainPackPanelViewModel.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/viewmodel/MainPackPanelViewModel.kt
@@ -78,7 +78,7 @@ class MainPackPanelViewModel(
 	}
 
 	fun youtubeClick() {
-		app.browse("https://www.youtube.com/results?search_query=UniPad+${unipack.title}+${unipack.producerName}")
+		app.browse("https://www.youtube.com/results?search_query=" + android.net.Uri.encode("UniPad ${unipack.title} ${unipack.producerName}"))
 	}
 
 	fun delete() {

--- a/app/src/main/java/com/kimjisub/launchpad/viewmodel/MainTotalPanelViewModel.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/viewmodel/MainTotalPanelViewModel.kt
@@ -62,7 +62,15 @@ class MainTotalPanelViewModel(
 	var sortOrder by mutableStateOf(true)
 		private set
 
+	// Fires once when the activity attaches: the saved sort used to be ignored until the user
+	// touched the sort control and the list came up in listFiles() order.
 	var onSortChanged: ((SortMethod, Boolean) -> Unit)? = null
+		set(value) {
+			field = value
+			value?.invoke(sortMethodList[sortMethod], sortOrder)
+			prevSortMethod = sortMethod
+			prevSortOrder = sortOrder
+		}
 
 	fun updateSortMethod(value: Int) {
 		sortMethod = value

--- a/app/src/main/java/com/kimjisub/launchpad/viewmodel/PlayActivityViewModel.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/viewmodel/PlayActivityViewModel.kt
@@ -819,7 +819,9 @@ class PlayActivityViewModel(
 						isPracticeMode = false
 						scbAutoPlay.setCheckedSilently(false)
 						autoPlayControlVisible = false
-						if (unipack.ledAnimationTable != null) {
+						// keyLedExist, like switchPlayMode and both other platforms: an empty keyLed/
+						// directory has a non-null table but no animations.
+						if (unipack.keyLedExist) {
 							scbLed.setChecked(true)
 							scbFeedbackLight.setChecked(false)
 						} else {
@@ -864,6 +866,8 @@ class PlayActivityViewModel(
 			override fun onException(throwable: Throwable) {
 				autoMappingActive = false
 				Log.err("AutoMapping failed", throwable)
+				// iOS tells the user; here the bar just disappeared.
+				viewModelScope.launch { uiCallback?.showToast(string.failed) }
 			}
 		})
 	}


### PR DESCRIPTION
## What

Parity fixes from the 2026-09-07 three-platform review (`design/2026-09-07/parity/*.md` in the private workspace repo). Android is the reference implementation; these are the places where iOS or web already behave better and Android should match.

### UniPack parser
- Text tables are read through a BOM-aware reader: UTF-16 with a BOM as iOS does, and a UTF-8 BOM is skipped. Notepad's BOM made the first key `﻿title` and the first line of every table was lost.
- Tokens split on Unicode space separators (U+00A0, U+3000 from a Korean IME). `\s` is ASCII-only, so such a line became one token and was dropped.
- `info`: non-numeric `buttonX`/`buttonY`/`chain` is recorded instead of throwing out of `load()` (the pack silently vanished from the library). `buttonX`/`buttonY` outside 0..64 is critical, as on iOS.
- `removeDoubleFolder` repeats up to 8 levels and ignores Finder's `__MACOSX` sibling. Every Mac-zipped pack was rejected on import.
- Downloader validates with `load().loadDetail()`. Without `load()`, `checkFile` never ran and any archive installed as a pack.

### Engine
- `ChannelManager`: a palette code outside 0..127 resolves to 0 instead of throwing.
- `UniPack.soundPush/ledPush(num)` rotation bounded by the queue length.
- AutoPlay `onEnd` restores LED/feedback from `keyLedExist`, like `switchPlayMode`.
- `DriverRef.sendSignal` clamps note/velocity to 0..127.

### Play screen
- "Hide UI" now hides the logo and the chrome column. The view model wrote `optionViewVisible` and nothing read it, so the switch only changed launchpad LEDs.
- Option panel background/accent come from the theme's `option_window` colours.
- A theme without `btn_` shows the pressed colour instead of nothing.
- Auto-mapping failure shows a toast.

### Main / store
- The saved sort applies at launch. The list came up in `listFiles()` order until the sort control was touched.
- A warning import refreshes the list.
- The file picker filters to zip types.
- Store download prefers the entry's `URL` and percent-encodes the code; YouTube search percent-encoded; the Website icon opens the entry URL (its handler was empty).
- `.nomedia` is written into SD-card workspaces.

### Themes
- ZIP themes accept `.webp`/`.jpg` and the alternate stems iOS/web accept; the icon is optional.

## Verification

| Check | Result |
|---|---|
| `:app:compileDebugKotlin` | ok |
| `:app:testDebugUnitTest` | 279 / 279 |
| `:app:lintDebug` | 0 errors |

UniPack tolerance only widened (BOM, UTF-16, Unicode spaces, deeper nesting); the one new rejection is `buttonX`/`buttonY` outside 0..64, which crashed or exhausted memory before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)