### PR TITLE
feat(i18n): 설정 문자열 6개를 나머지 16개 로케일에 번역

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -289,4 +289,10 @@
 	<string name="backup_recovery_message">%d UniPacks im Backup-Ordner gefunden.\nMöchten Sie sie wiederherstellen?</string>
 	<string name="backup_recovery_restore">Wiederherstellen</string>
 	<string name="backup_recovery_later">Später</string>
+	<string name="settings_play">Spielen</string>
+	<string name="trace_log_classic">Klassische Reihenfolge-Anzeige</string>
+	<string name="trace_log_classic_desc">Zeigt die Reihenfolge der Berührungen als Zahlen auf den Pads statt als Linien und Punkte</string>
+	<string name="slide_mode">Über Pads streichen</string>
+	<string name="slide_mode_desc">Wenn ein Finger auf ein Pad gezogen wird, klingt dieses Pad und das verlassene hört auf</string>
+	<string name="no_app_for_link">Auf diesem Gerät kann keine App diesen Link öffnen.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -289,4 +289,10 @@
 	<string name="backup_recovery_message">Se encontraron %d UniPacks en la carpeta de respaldo.\n¿Deseas restaurarlos?</string>
 	<string name="backup_recovery_restore">Restaurar</string>
 	<string name="backup_recovery_later">Después</string>
+	<string name="settings_play">Interpretación</string>
+	<string name="trace_log_classic">Orden de toques clásico</string>
+	<string name="trace_log_classic_desc">Muestra el orden de los toques como números en cada pad en lugar de líneas y puntos</string>
+	<string name="slide_mode">Deslizar por los pads</string>
+	<string name="slide_mode_desc">Al arrastrar el dedo hasta un pad, este suena y el pad que se abandona se detiene</string>
+	<string name="no_app_for_link">Ninguna app de este dispositivo puede abrir este enlace.</string>
 </resources>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -289,4 +289,10 @@
 	<string name="backup_recovery_message">%d UniPacks ang nakita sa backup folder.\nGusto mo bang i-restore ang mga ito?</string>
 	<string name="backup_recovery_restore">I-restore</string>
 	<string name="backup_recovery_later">Mamaya na</string>
+	<string name="settings_play">Pagtugtog</string>
+	<string name="trace_log_classic">Klasikong tala ng pagkakasunod</string>
+	<string name="trace_log_classic_desc">Ipakita ang pagkakasunod ng pag-tap bilang mga numero sa bawat pad sa halip na mga linya at tuldok</string>
+	<string name="slide_mode">Mag-slide sa mga pad</string>
+	<string name="slide_mode_desc">Kapag hinila ang daliri papunta sa isang pad, tutunog ito at hihinto ang pad na iniwan</string>
+	<string name="no_app_for_link">Walang app sa device na ito ang makakapagbukas ng link na ito.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -289,4 +289,10 @@
 	<string name="backup_recovery_message">%d UniPacks trouvés dans le dossier de sauvegarde.\nVoulez-vous les restaurer ?</string>
 	<string name="backup_recovery_restore">Restaurer</string>
 	<string name="backup_recovery_later">Plus tard</string>
+	<string name="settings_play">Jeu</string>
+	<string name="trace_log_classic">Ordre des appuis classique</string>
+	<string name="trace_log_classic_desc">Affiche l\'ordre des appuis sous forme de chiffres sur chaque pad au lieu de lignes et de points</string>
+	<string name="slide_mode">Glisser sur les pads</string>
+	<string name="slide_mode_desc">Faire glisser un doigt sur un pad le déclenche et arrête celui que l\'on quitte</string>
+	<string name="no_app_for_link">Aucune application de cet appareil ne peut ouvrir ce lien.</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -289,4 +289,10 @@
 	<string name="backup_recovery_message">बैकअप फ़ोल्डर में %d UniPacks मिले।\nक्या आप उन्हें पुनर्स्थापित करना चाहते हैं?</string>
 	<string name="backup_recovery_restore">पुनर्स्थापित करें</string>
 	<string name="backup_recovery_later">बाद में</string>
+	<string name="settings_play">बजाना</string>
+	<string name="trace_log_classic">क्लासिक टैप क्रम</string>
+	<string name="trace_log_classic_desc">टैप का क्रम रेखाओं और बिंदुओं के बजाय हर पैड पर संख्याओं में दिखाएँ</string>
+	<string name="slide_mode">पैड पर स्लाइड करें</string>
+	<string name="slide_mode_desc">उँगली खींचकर किसी पैड पर लाने से वह बजता है और छोड़ा गया पैड रुक जाता है</string>
+	<string name="no_app_for_link">इस डिवाइस पर कोई भी ऐप यह लिंक नहीं खोल सकता।</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -289,4 +289,10 @@
 	<string name="backup_recovery_message">%d UniPacks ditemukan di folder cadangan.\nApakah Anda ingin memulihkannya?</string>
 	<string name="backup_recovery_restore">Pulihkan</string>
 	<string name="backup_recovery_later">Nanti</string>
+	<string name="settings_play">Permainan</string>
+	<string name="trace_log_classic">Urutan ketukan klasik</string>
+	<string name="trace_log_classic_desc">Tampilkan urutan ketukan sebagai angka di setiap pad, bukan garis dan titik</string>
+	<string name="slide_mode">Geser antar pad</string>
+	<string name="slide_mode_desc">Menggeser jari ke sebuah pad akan membunyikannya dan menghentikan pad yang ditinggalkan</string>
+	<string name="no_app_for_link">Tidak ada aplikasi di perangkat ini yang dapat membuka tautan ini.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -289,4 +289,10 @@
 	<string name="backup_recovery_message">%d UniPacks trovati nella cartella di backup.\nVuoi ripristinarli?</string>
 	<string name="backup_recovery_restore">Ripristina</string>
 	<string name="backup_recovery_later">Più tardi</string>
+	<string name="settings_play">Esecuzione</string>
+	<string name="trace_log_classic">Ordine dei tocchi classico</string>
+	<string name="trace_log_classic_desc">Mostra l\'ordine dei tocchi come numeri su ogni pad invece che con linee e punti</string>
+	<string name="slide_mode">Scorri sui pad</string>
+	<string name="slide_mode_desc">Trascinando un dito su un pad, questo suona e quello che si lascia si ferma</string>
+	<string name="no_app_for_link">Nessuna app su questo dispositivo può aprire questo link.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -289,4 +289,10 @@
 	<string name="backup_recovery_message">バックアップフォルダに%d個のUniPacksが見つかりました。\n復元しますか？</string>
 	<string name="backup_recovery_restore">復元</string>
 	<string name="backup_recovery_later">後で</string>
+	<string name="settings_play">演奏</string>
+	<string name="trace_log_classic">従来の順序表示</string>
+	<string name="trace_log_classic_desc">タップした順番を線と点ではなく各パッドの数字で表示します</string>
+	<string name="slide_mode">パッドをなぞる</string>
+	<string name="slide_mode_desc">指をなぞって別のパッドに入るとそのパッドが鳴り、離れたパッドは止まります</string>
+	<string name="no_app_for_link">この端末にはこのリンクを開けるアプリがありません。</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -289,4 +289,10 @@
 	<string name="backup_recovery_message">%d UniPacks ditemui dalam folder sandaran.\nAdakah anda ingin memulihkannya?</string>
 	<string name="backup_recovery_restore">Pulihkan</string>
 	<string name="backup_recovery_later">Kemudian</string>
+	<string name="settings_play">Permainan</string>
+	<string name="trace_log_classic">Urutan ketikan klasik</string>
+	<string name="trace_log_classic_desc">Tunjukkan urutan ketikan sebagai nombor pada setiap pad, bukan garis dan titik</string>
+	<string name="slide_mode">Luncur pada pad</string>
+	<string name="slide_mode_desc">Menyeret jari ke sebuah pad akan membunyikannya dan menghentikan pad yang ditinggalkan</string>
+	<string name="no_app_for_link">Tiada aplikasi pada peranti ini yang boleh membuka pautan ini.</string>
 </resources>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -289,4 +289,10 @@
 	<string name="backup_recovery_message">အရန်ဖိုင်တွဲတွင် UniPacks %d ခု တွေ့ရှိပါသည်။\n၎င်းတို့ကို ပြန်လည်ရယူလိုပါသလား?</string>
 	<string name="backup_recovery_restore">ပြန်လည်ရယူရန်</string>
 	<string name="backup_recovery_later">နောက်မှ</string>
+	<string name="settings_play">တီးခတ်ခြင်း</string>
+	<string name="trace_log_classic">ရိုးရာ အစဉ်ပြခြင်း</string>
+	<string name="trace_log_classic_desc">ထိထားသည့် အစဉ်ကို မျဉ်းနှင့် အစက်များအစား ပက်တစ်ခုစီပေါ်တွင် ဂဏန်းဖြင့် ပြပါ</string>
+	<string name="slide_mode">ပက်များပေါ် ပွတ်ဆွဲခြင်း</string>
+	<string name="slide_mode_desc">လက်ချောင်းကို ပက်တစ်ခုပေါ် ဆွဲတင်လျှင် ထိုပက် မြည်ပြီး ထွက်ခွာလာသော ပက် ရပ်သွားပါသည်</string>
+	<string name="no_app_for_link">ဤစက်ပစ္စည်းတွင် ဤလင့်ခ်ကို ဖွင့်နိုင်သော အက်ပ် မရှိပါ။</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -289,4 +289,10 @@
 	<string name="backup_recovery_message">%d UniPacks encontrados na pasta de backup.\nDeseja restaurá-los?</string>
 	<string name="backup_recovery_restore">Restaurar</string>
 	<string name="backup_recovery_later">Depois</string>
+	<string name="settings_play">Execução</string>
+	<string name="trace_log_classic">Ordem de toques clássica</string>
+	<string name="trace_log_classic_desc">Mostra a ordem dos toques como números em cada pad, em vez de linhas e pontos</string>
+	<string name="slide_mode">Deslizar pelos pads</string>
+	<string name="slide_mode_desc">Arrastar o dedo até um pad faz com que ele soe e para o pad que foi deixado</string>
+	<string name="no_app_for_link">Nenhum app neste dispositivo pode abrir este link.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -289,4 +289,10 @@
 	<string name="backup_recovery_message">Найдено %d UniPacks в папке резервного копирования.\nХотите восстановить их?</string>
 	<string name="backup_recovery_restore">Восстановить</string>
 	<string name="backup_recovery_later">Позже</string>
+	<string name="settings_play">Игра</string>
+	<string name="trace_log_classic">Классический порядок нажатий</string>
+	<string name="trace_log_classic_desc">Показывать порядок нажатий цифрами на пэдах вместо линий и точек</string>
+	<string name="slide_mode">Скольжение по пэдам</string>
+	<string name="slide_mode_desc">Если провести пальцем на другой пэд, он зазвучит, а покинутый остановится</string>
+	<string name="no_app_for_link">На этом устройстве нет приложения, способного открыть эту ссылку.</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -289,4 +289,10 @@
 	<string name="backup_recovery_message">พบ %d UniPacks ในโฟลเดอร์สำรองข้อมูล\nคุณต้องการกู้คืนหรือไม่?</string>
 	<string name="backup_recovery_restore">กู้คืน</string>
 	<string name="backup_recovery_later">ภายหลัง</string>
+	<string name="settings_play">การเล่น</string>
+	<string name="trace_log_classic">ลำดับการแตะแบบเดิม</string>
+	<string name="trace_log_classic_desc">แสดงลำดับการแตะเป็นตัวเลขบนแต่ละแพด แทนเส้นและจุด</string>
+	<string name="slide_mode">เลื่อนนิ้วข้ามแพด</string>
+	<string name="slide_mode_desc">การลากนิ้วไปยังแพดหนึ่งจะทำให้แพดนั้นดัง และหยุดแพดที่ออกมา</string>
+	<string name="no_app_for_link">ไม่มีแอปในอุปกรณ์นี้ที่เปิดลิงก์นี้ได้</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -289,4 +289,10 @@
 	<string name="backup_recovery_message">Yedek klasöründe %d UniPack bulundu.\nGeri yüklemek ister misiniz?</string>
 	<string name="backup_recovery_restore">Geri Yükle</string>
 	<string name="backup_recovery_later">Daha Sonra</string>
+	<string name="settings_play">Çalma</string>
+	<string name="trace_log_classic">Klasik dokunma sırası</string>
+	<string name="trace_log_classic_desc">Dokunma sırasını çizgi ve nokta yerine her pad üzerinde sayı olarak gösterir</string>
+	<string name="slide_mode">Padler arasında kaydırma</string>
+	<string name="slide_mode_desc">Parmağı bir pad üzerine sürüklemek onu çalar ve ayrılan pad durur</string>
+	<string name="no_app_for_link">Bu cihazda bu bağlantıyı açabilecek bir uygulama yok.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -289,4 +289,10 @@
 	<string name="backup_recovery_message">Tìm thấy %d UniPacks trong thư mục sao lưu.\nBạn có muốn khôi phục không?</string>
 	<string name="backup_recovery_restore">Khôi phục</string>
 	<string name="backup_recovery_later">Để sau</string>
+	<string name="settings_play">Chơi nhạc</string>
+	<string name="trace_log_classic">Thứ tự chạm kiểu cũ</string>
+	<string name="trace_log_classic_desc">Hiển thị thứ tự chạm bằng số trên từng pad thay vì đường kẻ và chấm</string>
+	<string name="slide_mode">Trượt qua các pad</string>
+	<string name="slide_mode_desc">Kéo ngón tay sang một pad sẽ phát pad đó và dừng pad vừa rời khỏi</string>
+	<string name="no_app_for_link">Không có ứng dụng nào trên thiết bị này mở được liên kết này.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -291,4 +291,10 @@
 	<string name="backup_recovery_message">在备份文件夹中发现 %d 个 UniPacks。\n是否要恢复？</string>
 	<string name="backup_recovery_restore">恢复</string>
 	<string name="backup_recovery_later">稍后</string>
+	<string name="settings_play">演奏</string>
+	<string name="trace_log_classic">经典顺序显示</string>
+	<string name="trace_log_classic_desc">在每个打击垫上用数字显示点击顺序，而不是线条和圆点</string>
+	<string name="slide_mode">滑过打击垫</string>
+	<string name="slide_mode_desc">手指滑到某个打击垫时该垫发声，离开的垫则停止</string>
+	<string name="no_app_for_link">此设备上没有可以打开该链接的应用。</string>
 </resources>


### PR DESCRIPTION
## 무엇

`lintDebug` 가 `MissingTranslation` 을 내던 문자열 6개입니다. classic trace log 설정(#45), 링크 폴백 토스트(#53), Slide Mode(#56) 와 함께 들어온 것들이고 영어와 한국어에만 있었습니다. 17개 로케일이 런타임에 영어로 떨어졌고, 빌드를 깨지 않으려고 lint 를 경고로 내려 둔 상태였습니다.

96건입니다. de 부터 zh-rCN 까지.

## 두 가지 판단

**`settings_play` 의 "Play" 는 섹션 제목입니다.** 동사도 아니고 미디어 재생도 아니고, 팩을 어떻게 연주하는가에 대한 설정 묶음입니다. 한국어가 이미 `연주` 로 풀었고, 연주와 재생을 구분하는 언어들은 재생 쪽이 아니라 그쪽을 따랐습니다. Interpretación, Esecuzione, Execução, 演奏.

**"trace log" 는 디버그 로그가 아닙니다.** 패드에 누른 순서를 숫자로 보여주는 이 앱의 고유 용어입니다. 로그로 번역하면 16개 언어에서 한꺼번에 틀립니다. 그래서 전부 "보여주는 것" 으로 옮겼습니다.

프랑스어와 이탈리아어의 아포스트로피는 안드로이드 리소스 파서용으로 이스케이프했습니다.

## 검증

| 항목 | 결과 |
|---|---|
| `lintDebug` MissingTranslation | 0건 |
| lint error 등급 | 0건 (전체 55건 전부 정보성) |
| `:app:testDebugUnitTest` | 통과 |
| strings.xml 16개 파싱 | 전부 정상 |

워크스페이스 T-0023 입니다.