### PR TITLE
fix(import): 딥링크가 확인 없이 팩을 설치하던 것

### DIFF
--- a/app/src/main/java/com/kimjisub/launchpad/activity/ImportPackByUrlActivity.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/activity/ImportPackByUrlActivity.kt
@@ -7,17 +7,22 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -43,11 +48,25 @@ import java.io.IOException
 class ImportPackByUrlActivity : BaseActivity() {
 	companion object {
 		private const val INSTALL_COMPLETE_DELAY_MS = 3000L
+
+		/** Shown with the question so the person can see where the file comes from. */
+		private const val UNISHARE_HOST = "api.unipad.io"
 	}
 
 	private val titleText = mutableStateOf("")
 	private val messageText = mutableStateOf("")
 	private val infoText = mutableStateOf("")
+
+	/**
+	 * The pack a deep link wants to install, held while the user decides.
+	 *
+	 * A `unipad://` link used to go straight from the metadata response into the
+	 * download. Anything that can open a link on this device could therefore make
+	 * the app fetch and unpack a file with no say from the person holding it. The
+	 * metadata call already ran by this point, so the question can name the pack
+	 * and its producer instead of asking about an anonymous download.
+	 */
+	private val pendingInstall = mutableStateOf<UnishareVO?>(null)
 
 	private val code: String? by lazy { intent?.data?.getQueryParameter("code") }
 
@@ -66,10 +85,14 @@ class ImportPackByUrlActivity : BaseActivity() {
 			val title by titleText
 			val message by messageText
 			val info by infoText
+			val pending by pendingInstall
 			ImportPackScreen(
 				titleText = title,
 				messageText = message,
 				infoText = info,
+				confirming = pending != null,
+				onAccept = { pending?.let { startInstall(it) } },
+				onCancel = { finish() },
 			)
 		}
 
@@ -85,7 +108,11 @@ class ImportPackByUrlActivity : BaseActivity() {
 					log("title: ${unishare.title}")
 					log("producerName: ${unishare.producer}")
 
-					startInstall(unishare)
+					// Ask first. The download starts from onAccept, not from here.
+					titleText.value = unishare.title.orEmpty()
+					messageText.value = unishare.producer.orEmpty()
+					infoText.value = getString(string.import_pack_confirm_source, UNISHARE_HOST)
+					pendingInstall.value = unishare
 				} else {
 					when (response.code()) {
 						404 -> {
@@ -105,6 +132,7 @@ class ImportPackByUrlActivity : BaseActivity() {
 	}
 
 	fun startInstall(unishare: UnishareVO) {
+		pendingInstall.value = null
 		val packTitle = getString(string.import_pack_title_format, unishare.title, unishare._id)
 		UniPackDownloader(
 			context = this,
@@ -198,6 +226,9 @@ private fun ImportPackScreen(
 	titleText: String,
 	messageText: String,
 	infoText: String,
+	confirming: Boolean = false,
+	onAccept: () -> Unit = {},
+	onCancel: () -> Unit = {},
 ) {
 	Box(
 		modifier = Modifier
@@ -239,6 +270,27 @@ private fun ImportPackScreen(
 					fontSize = 18.sp,
 					textAlign = TextAlign.Center,
 				)
+
+				if (confirming) {
+					Text(
+						text = stringResource(string.import_pack_confirm),
+						color = grayColor,
+						fontSize = 14.sp,
+						textAlign = TextAlign.Center,
+						modifier = Modifier.padding(top = 12.dp),
+					)
+					Row(
+						modifier = Modifier.padding(top = 8.dp),
+						horizontalArrangement = Arrangement.spacedBy(8.dp),
+					) {
+						TextButton(onClick = onCancel) {
+							Text(text = stringResource(string.cancel), color = grayColor)
+						}
+						TextButton(onClick = onAccept) {
+							Text(text = stringResource(string.accept), color = grayColor)
+						}
+					}
+				}
 			}
 		}
 	}

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -295,4 +295,6 @@
 	<string name="server_error_format">서버 오류\n%s</string>
 	<string name="download_progress_format">%1$d%%\n%2$s / %3$s MB</string>
 	<string name="option_indicator_format">%s ●</string>
+	<string name="import_pack_confirm">이 팩을 설치할까요?</string>
+	<string name="import_pack_confirm_source">%s 에서</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -305,4 +305,6 @@
 	<string name="import_pack_info_format">#%1$s\n%2$s\n%3$s</string>
 	<string name="server_error_format">server error\n%s</string>
 	<string name="download_progress_format">%1$d%%\n%2$s / %3$s MB</string>
+	<string name="import_pack_confirm">Install this pack?</string>
+	<string name="import_pack_confirm_source">from %s</string>
 </resources>


### PR DESCRIPTION
## 무엇이 잘못됐나

`unipad://…?code=` 링크를 열면 메타데이터 응답에서 곧장 다운로드로 넘어갔습니다. 이 기기에서 URL 을 열 수 있는 것이면 무엇이든 UniPad 가 파일을 받아 풀게 만들 수 있었습니다. 폰을 든 사람의 동의가 어디에도 없습니다.

## 어떻게 고쳤나

메타데이터 호출은 이미 다운로드보다 먼저 돌고 있었습니다. 그래서 **팩 이름과 제작자, 그리고 어디서 받는지**를 보여주고 물을 수 있습니다. 익명의 다운로드를 묻는 것과 다릅니다. 읽는 다이얼로그와 그냥 닫는 다이얼로그의 차이가 거기입니다.

다운로드는 이제 설치 버튼에서 시작합니다. 취소하면 액티비티가 닫힙니다.

## 세 플랫폼 동시

같은 결함이 iOS 와 웹에도 **같은 코드 모양으로** 있었습니다(R-107). 세 PR 을 같은 패스에서 냅니다.

- iOS: kimjisub/unipad-ios#12
- 웹: kimjisub/unipad.io#16

## 검증

`:app:compileDebugKotlin` 성공. 문자열은 영어·한국어를 채웠고 나머지 16개 로케일은 영어로 폴백합니다.

워크스페이스 T-0011.