### PR TITLE
fix(midi): 표시 이름을 Mystrix 로, 감지는 그대로

### DIFF
--- a/app/src/main/java/com/kimjisub/launchpad/midi/MidiConnection.kt
+++ b/app/src/main/java/com/kimjisub/launchpad/midi/MidiConnection.kt
@@ -319,9 +319,13 @@ object MidiConnection {
 				driver = entry.factory()
 				publishConnectedDevice(entry.name)
 			} else if (pid and MATRIX_PRODUCT_ID_MASK == MATRIX_PRODUCT_ID_BASE) {
-				listener?.onUiLog("prediction : 203 Matrix")
+				// Detection stays on the product id. The device renamed itself in
+				// firmware (Matrix -> Mystrix) but the PID did not move, so only the
+				// name shown to the user needs to follow. iOS and the web match on the
+				// announced name and do have to carry both spellings.
+				listener?.onUiLog("prediction : 203 Mystrix")
 				driver = Matrix()
-				publishConnectedDevice("Matrix")
+				publishConnectedDevice("Mystrix")
 			} else {
 				listener?.onUiLog("prediction : unknown (PID=$pid)")
 				driver = MasterKeyboard()


### PR DESCRIPTION
기기가 펌웨어에서 이름을 바꿨습니다. 구버전은 `Matrix` / `Matrix Pro`, 신버전은 `Mystrix` / `Mystrix Pro` 를 MIDI 로 알립니다. 기여자가 실기기로 확인해 줬습니다(kimjisub/unipad-ios#13).

**안드로이드는 그 이름으로 잡은 적이 없습니다.** USB PID 로 고르고(`pid and 0xFFC0 == 0x1040`), 펌웨어 이름이 바뀌어도 PID 는 안 움직입니다. 그래서 감지는 그대로 두고 사용자에게 보이는 이름만 따라갑니다.

주석에 그 이유를 적었습니다. 여기서 다음에 하기 쉬운 편집이 "이름 검사도 넣자" 인데, 아무 일도 안 하면서 이 경로를 나머지 둘처럼 보이게만 만듭니다.

iOS 와 웹은 알려진 이름으로 잡아서 두 철자를 다 들고 있어야 합니다. iOS 는 #13 으로 이미 됐고, 웹은 같은 패스에서 PR 을 냈습니다.

검증: `:app:compileDebugKotlin` 성공. 워크스페이스 T-0054.